### PR TITLE
Radio button group fieldset

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -87,6 +87,8 @@ module.exports = function (t, fields, options) {
         return {
             'key': key,
             'error': this.errors && this.errors[key],
+            'legend': fields[key].legend && fields[key].legend.value,
+            'legend-display': fields[key].legend && fields[key].legend.display,
             'options': _.map(fields[key].options, function (obj) {
                 var selected = false, label, value, toggle;
 

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -88,7 +88,6 @@ module.exports = function (t, fields, options) {
             'key': key,
             'error': this.errors && this.errors[key],
             'legend': fields[key].legend && fields[key].legend.value,
-            'legend-display': fields[key].legend && fields[key].legend.display,
             'options': _.map(fields[key].options, function (obj) {
                 var selected = false, label, value, toggle;
 

--- a/partials/forms/radio-group.html
+++ b/partials/forms/radio-group.html
@@ -1,4 +1,5 @@
-<div id="{{key}}-group" class="form-group{{#display}} {{display}}{{/display}}{{#error}} validation-error{{/error}}">
+<fieldset id="{{key}}-group" class="{{#display}}{{display}}{{/display}}{{#error}} validation-error{{/error}}">
+    <legend{{#legend-display}} class="{{legend-display}}"{{/legend-display}}>{{legend}}</legend>
     {{#options}}
         <label class="block-label" for="{{key}}-{{value}}">
             <input
@@ -9,4 +10,4 @@
             {{{label}}}
         </label>
     {{/options}}
-</div>
+</fieldset>

--- a/partials/forms/radio-group.html
+++ b/partials/forms/radio-group.html
@@ -1,5 +1,5 @@
 <fieldset id="{{key}}-group" class="{{#display}}{{display}}{{/display}}{{#error}} validation-error{{/error}}">
-    <legend{{#legend-display}} class="{{legend-display}}"{{/legend-display}}>{{legend}}</legend>
+    <legend class="visuallyhidden">{{legend}}</legend>
     {{#options}}
         <label class="block-label" for="{{key}}-{{value}}">
             <input


### PR DESCRIPTION
Radio button groups should always be wrapped by a fieldset. A fieldset should always contain a legend.

Swop the wrapping div for a fieldset and remove `.form-group`. Add a legend with optional CSS classes.