### PR TITLE
Unescaped HTML for input[type="text"] label

### DIFF
--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -1,5 +1,5 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
-    <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">{{label}}</label>
+    <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">{{{label}}}</label>
     {{#hint}}<p class="form-hint">{{hint}}</p>{{/hint}}
     <input type="{{type}}" id="{{id}}" class="form-control{{#class}} {{class}}{{/class}}{{#postcode}} postcode{{/postcode}}{{#error}} invalid-input{{/error}}" name="{{id}}"{{#value}} value="{{value}}"{{/value}}{{#min}} min="{{min}}"{{/min}}{{#max}} max="{{max}}"{{/max}}{{#maxlength}} maxlength="{{maxlength}}"{{/maxlength}}{{#pattern}} pattern="{{pattern}}"{{/pattern}} aria-required="{{required}}">
 </div>


### PR DESCRIPTION
There's a need to show a label on an address entry page that contains hidden text using `span.visuallyhidden`.

Allow unescaped HTML for the label in input-text-group mixin.