### PR TITLE
JS focusable radio group fieldset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmpo-template-mixins",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.",
   "main": "index.js",
   "scripts": {

--- a/partials/forms/radio-group.html
+++ b/partials/forms/radio-group.html
@@ -1,4 +1,4 @@
-<fieldset id="{{key}}-group" class="{{#display}}{{display}}{{/display}}{{#error}} validation-error{{/error}}">
+<fieldset id="{{key}}-group" class="{{#display}}{{display}}{{/display}}{{#error}} validation-error{{/error}}" tabindex="-1">
     <legend class="visuallyhidden">{{legend}}</legend>
     {{#options}}
         <label class="block-label" for="{{key}}-{{value}}">


### PR DESCRIPTION
Add `tabindex="-1"` to radio group fieldset so that we can add focus via JavaScript.