### PR TITLE
Add optional date formatting

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -260,8 +260,9 @@ module.exports = function (t, fields, options) {
 
         res.locals.date = function () {
             return function (txt) {
-                var value = Hogan.compile(txt).render(this);
-                return moment(value).format('D MMMM YYYY');
+                txt = (txt || '').split('|');
+                var value = Hogan.compile(txt[0]).render(this);
+                return moment(value).format(txt[1] || 'D MMMM YYYY');
             };
         };
 

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -196,4 +196,32 @@ describe('Template Mixins', function () {
 
     });
 
+    describe('date', function () {
+
+        beforeEach(function () {
+            middleware = mixins(translate, {});
+        });
+
+        it('adds a function to res.locals', function () {
+            middleware(req, res, next);
+            res.locals['date'].should.be.a('function');
+        });
+
+        it('returns a function', function () {
+            middleware(req, res, next);
+            res.locals['date']().should.be.a('function');
+        });
+
+        it('formats a date', function () {
+            middleware(req, res, next);
+            res.locals['date']().call(res.locals, '2015-03-26').should.equal('26 March 2015');
+        });
+
+        it('applys a date format if specified', function () {
+            middleware(req, res, next);
+            res.locals['date']().call(res.locals, '2015-03|MMMM YYYY').should.equal('March 2015');
+        });
+
+    });
+
 });


### PR DESCRIPTION
Add date formatting based on @lennym's comments in https://github.com/UKHomeOffice/passports-template-mixins/pull/11.

A date format can also be passed into the date mixin after the date, split by a pipe, i.e. `2015-03|MMMM YYYY`.

Add unit tests.