### PR TITLE
Input maxlength value

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -86,7 +86,7 @@ module.exports = function (t, fields, options) {
             label: t(sharedTranslationsKey + 'fields.' + key + '.label'),
             hint: i18nLookup(sharedTranslationsKey + 'fields.' + key + '.hint'),
             error: this.errors && this.errors[key],
-            maxlength: extension.maxlength || maxlength(key),
+            maxlength: maxlength(key) || extension.maxlength,
             required: extension.required !== undefined ? extension.required : true,
             pattern: extension.pattern
         });

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -87,6 +87,21 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('uses maxlength property set at a field level over default option', function () {
+                middleware = mixins(translate, {
+                    'field-name': {
+                        'validate': [
+                            { type: 'maxlength', arguments: 10 }
+                        ]
+                    }
+                });
+                middleware(req, res, next);
+                res.locals['input-phone']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    maxlength: 10
+                }));
+            });
+
         });
 
         describe('input-date', function () {


### PR DESCRIPTION
Phone number length validation across projects is different.

Use maxlength set at a field level over the value set in the template mixins.