### PR TITLE
Accessible input hints

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -85,6 +85,7 @@ module.exports = function (t, fields, options) {
             value: this.values && this.values[key],
             label: t(sharedTranslationsKey + 'fields.' + key + '.label'),
             hint: i18nLookup(sharedTranslationsKey + 'fields.' + key + '.hint'),
+            hintId: extension.hintId,
             error: this.errors && this.errors[key],
             maxlength: maxlength(key) || extension.maxlength,
             required: extension.required !== undefined ? extension.required : true,
@@ -158,12 +159,12 @@ module.exports = function (t, fields, options) {
                     dayPart, monthPart, yearPart;
 
                 if (isExact) {
-                    dayPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-day', { pattern: '[0-9]*', min: 1, max: 31, maxlength: 2 }));
+                    dayPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-day', { pattern: '[0-9]*', min: 1, max: 31, maxlength: 2, hintId: key + '-hint' }));
                     parts.push(dayPart);
                 }
 
-                monthPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-month', { pattern: '[0-9]*', min: 1, max: 12, maxlength: 2 }));
-                yearPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-year', { pattern: '[0-9]*', maxlength: 4 }));
+                monthPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-month', { pattern: '[0-9]*', min: 1, max: 12, maxlength: 2, hintId: key + '-hint' }));
+                yearPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-year', { pattern: '[0-9]*', maxlength: 4, hintId: key + '-hint' }));
                 parts = parts.concat(monthPart, yearPart);
 
                 return parts.join('\n');

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -78,14 +78,15 @@ module.exports = function (t, fields, options) {
 
     function inputText(key, extension) {
         extension = extension || {};
+        var hint = i18nLookup(sharedTranslationsKey + 'fields.' + key + '.hint');
         return _.extend(extension, {
             id: key,
             className: extension.className || classnames(key),
             type: extension.type || type(key),
             value: this.values && this.values[key],
             label: t(sharedTranslationsKey + 'fields.' + key + '.label'),
-            hint: i18nLookup(sharedTranslationsKey + 'fields.' + key + '.hint'),
-            hintId: extension.hintId,
+            hint: hint,
+            hintId: extension.hintId || (hint ? key + '-hint' : null),
             error: this.errors && this.errors[key],
             maxlength: maxlength(key) || extension.maxlength,
             required: extension.required !== undefined ? extension.required : true,

--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -1,5 +1,5 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
     <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">{{{label}}}</label>
     {{#hint}}<p id="{{id}}-hint" class="form-hint">{{hint}}</p>{{/hint}}
-    <input type="{{type}}" id="{{id}}" class="form-control{{#className}} {{className}}{{/className}}{{#postcode}} postcode{{/postcode}}{{#error}} invalid-input{{/error}}" name="{{id}}"{{#value}} value="{{value}}"{{/value}}{{#min}} min="{{min}}"{{/min}}{{#max}} max="{{max}}"{{/max}}{{#maxlength}} maxlength="{{maxlength}}"{{/maxlength}}{{#pattern}} pattern="{{pattern}}"{{/pattern}}{{#hint}} aria-describedby="{{id}}-hint"{{/hint}}{{#hintId}} aria-describedby="{{hintId}}"{{/hintId}} aria-required="{{required}}">
+    <input type="{{type}}" id="{{id}}" class="form-control{{#className}} {{className}}{{/className}}{{#postcode}} postcode{{/postcode}}{{#error}} invalid-input{{/error}}" name="{{id}}"{{#value}} value="{{value}}"{{/value}}{{#min}} min="{{min}}"{{/min}}{{#max}} max="{{max}}"{{/max}}{{#maxlength}} maxlength="{{maxlength}}"{{/maxlength}}{{#pattern}} pattern="{{pattern}}"{{/pattern}}{{#hintId}} aria-describedby="{{hintId}}"{{/hintId}} aria-required="{{required}}">
 </div>

--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -1,5 +1,5 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
     <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">{{{label}}}</label>
-    {{#hint}}<p class="form-hint">{{hint}}</p>{{/hint}}
-    <input type="{{type}}" id="{{id}}" class="form-control{{#className}} {{className}}{{/className}}{{#postcode}} postcode{{/postcode}}{{#error}} invalid-input{{/error}}" name="{{id}}"{{#value}} value="{{value}}"{{/value}}{{#min}} min="{{min}}"{{/min}}{{#max}} max="{{max}}"{{/max}}{{#maxlength}} maxlength="{{maxlength}}"{{/maxlength}}{{#pattern}} pattern="{{pattern}}"{{/pattern}} aria-required="{{required}}">
+    {{#hint}}<p id="{{id}}-hint" class="form-hint">{{hint}}</p>{{/hint}}
+    <input type="{{type}}" id="{{id}}" class="form-control{{#className}} {{className}}{{/className}}{{#postcode}} postcode{{/postcode}}{{#error}} invalid-input{{/error}}" name="{{id}}"{{#value}} value="{{value}}"{{/value}}{{#min}} min="{{min}}"{{/min}}{{#max}} max="{{max}}"{{/max}}{{#maxlength}} maxlength="{{maxlength}}"{{/maxlength}}{{#pattern}} pattern="{{pattern}}"{{/pattern}}{{#hint}} aria-describedby="{{id}}-hint"{{/hint}}{{#hintId}} aria-describedby="{{hintId}}"{{/hintId}} aria-required="{{required}}">
 </div>


### PR DESCRIPTION
Inputs need to be linked to form hints (where they exist) by use of `aria-describedby`.

For single input fields, ie passport number, add `aria-describedby`, which will be shown if a hint exists. Add an ID to the hint so that input is linked to this.

For date groups, a hint is shown at a group level and not individually. Update the template mixin to send `hintId`, which is used in another `aria-describedby`. The hint ID will need to be manually added to the group hint for date inputs.