### PR TITLE
Add error messages to form groups

### DIFF
--- a/partials/forms/checkbox.html
+++ b/partials/forms/checkbox.html
@@ -1,6 +1,8 @@
 <div id="{{key}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
+    {{#error}}<p class="error-message" aria-hidden="true">{{error.message}}</p>{{/error}}
     <label for="{{key}}" class="block-label{{#invalid}} invalid-input{{/invalid}}">
-        <input type="checkbox" id="{{key}}" name="{{key}}" value="true" aria-required="{{required}}"{{^error}}{{#toggle}} data-toggle="{{toggle}}"{{/toggle}}{{#selected}} checked="checked"{{/selected}}{{/error}}>
+        <input type="checkbox" id="{{key}}" name="{{key}}" value="true" aria-required="{{required}}"{{#error}} aria-invalid="true"{{/error}}{{^error}}{{#toggle}} data-toggle="{{toggle}}"{{/toggle}}{{#selected}} checked="checked"{{/selected}}{{/error}}>
         {{{label}}}
+        {{#error}}<span class="visuallyhidden">{{error.message}}</span>{{/error}}
     </label>
 </div>

--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -1,5 +1,21 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
-    <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">{{{label}}}</label>
-    {{#hint}}<p id="{{id}}-hint" class="form-hint">{{hint}}</p>{{/hint}}
-    <input type="{{type}}" id="{{id}}" class="form-control{{#className}} {{className}}{{/className}}{{#error}} invalid-input{{/error}}" name="{{id}}"{{#value}} value="{{value}}"{{/value}}{{#min}} min="{{min}}"{{/min}}{{#max}} max="{{max}}"{{/max}}{{#maxlength}} maxlength="{{maxlength}}"{{/maxlength}}{{#pattern}} pattern="{{pattern}}"{{/pattern}}{{#hintId}} aria-describedby="{{hintId}}"{{/hintId}} aria-required="{{required}}">
+    <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">
+        {{#error}}<span class="error-message" aria-hidden="true">{{error.message}}</span>{{/error}}
+        {{{label}}}
+        {{#hint}}<span class="form-hint">{{hint}}</span>{{/hint}}
+        {{#error}}<span class="visuallyhidden">{{error.message}}</span>{{/error}}
+    </label>
+    <input
+        type="{{type}}"
+        name="{{id}}"
+        id="{{id}}"
+        class="form-control{{#className}} {{className}}{{/className}}{{#error}} invalid-input{{/error}}"
+        aria-required="{{required}}"
+        {{#value}} value="{{value}}"{{/value}}
+        {{#min}} min="{{min}}"{{/min}}
+        {{#max}} max="{{max}}"{{/max}}
+        {{#maxlength}} maxlength="{{maxlength}}"{{/maxlength}}
+        {{#pattern}} pattern="{{pattern}}"{{/pattern}}
+        {{#error}} aria-invalid="true"{{/error}}
+    >
 </div>

--- a/partials/forms/radio-group.html
+++ b/partials/forms/radio-group.html
@@ -1,12 +1,20 @@
-<fieldset id="{{key}}-group" class="{{#display}}{{display}}{{/display}}{{#error}} validation-error{{/error}}" tabindex="-1">
-    <legend class="visuallyhidden">{{legend}}</legend>
+<fieldset id="{{key}}-group" class="{{#display}}{{display}}{{/display}}{{#error}} validation-error{{/error}}">
+    <legend>
+        {{#error}}<span id="{{key}}-error" class="error-message">{{error.message}}</span>{{/error}}
+        <span class="visuallyhidden">{{legend}}</span>
+    </legend>
     {{#options}}
         <label class="block-label" for="{{key}}-{{value}}">
             <input
-            type="radio" name="{{key}}" id="{{key}}-{{value}}" value="{{value}}"
-            aria-required="true"
-            {{#toggle}} data-toggle="{{toggle}}"{{/toggle}}
-            {{#selected}} checked="checked"{{/selected}}>
+                type="radio"
+                name="{{key}}"
+                id="{{key}}-{{value}}"
+                value="{{value}}"
+                aria-required="true"
+                {{#toggle}} data-toggle="{{toggle}}"{{/toggle}}
+                {{#selected}} checked="checked"{{/selected}}
+                {{#error}} aria-describedby="{{key}}-error" aria-invalid="true"{{/error}}
+            >
             {{{label}}}
         </label>
     {{/options}}


### PR DESCRIPTION
Depending on the input type there may be two versions of the error message, this is for visually impaired and sighted users. It is intended that the error message is presented in the correct order depending on the context. Each user will only see or hear the error message. This is achieved by using `aria-hidden="true"` and `.visuallyhidden`. Where there is only one instance of the error message, `aria-describedby` is used. Invalid fields are also marked up with `aria-invalid="true"`.