### PR TITLE
Create `url` mixin for dynamic url rendering

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -326,6 +326,13 @@ module.exports = function (t, fields, options) {
             };
         };
 
+        res.locals.url = function () {
+            return function (url) {
+                url = Hogan.compile(url).render(this);
+                return path.resolve(req.baseUrl, url);
+            };
+        };
+
         next();
     };
 

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -290,6 +290,34 @@ describe('Template Mixins', function () {
 
         });
 
+        describe('url', function () {
+
+            beforeEach(function () {
+                middleware = mixins(translate, {});
+            });
+
+            it('prepends the baseUrl to relative paths', function () {
+                req.baseUrl = '/base';
+                middleware(req, res, next);
+                res.locals.url().call(res.locals, './path').should.equal('/base/path');
+                res.locals.url().call(res.locals, 'path').should.equal('/base/path');
+            });
+
+            it('does not prepend the baseUrl to absolute paths', function () {
+                req.baseUrl = '/base';
+                middleware(req, res, next);
+                res.locals.url().call(res.locals, '/path').should.equal('/path');
+            });
+
+            it('supports urls defined in template placeholders', function () {
+                req.baseUrl = '/base';
+                res.locals.href = './link'
+                middleware(req, res, next);
+                res.locals.url().call(res.locals, '{{href}}').should.equal('/base/link');
+            });
+
+        });
+
     });
 
 });


### PR DESCRIPTION
We need to add logic to url rendering to support both relative links with a baseUrl and absolute ones without. This cannot easily be achieved with the string concatenation methods used before so requires the addition of a mixin.