### PR TITLE
Improve date validation

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -102,7 +102,8 @@ module.exports = function (fields, options) {
                 error: this.errors && this.errors[key],
                 maxlength: maxlength(key) || extension.maxlength,
                 required: extension.required !== undefined ? extension.required : true,
-                pattern: extension.pattern
+                pattern: extension.pattern,
+                date: extension.date
             });
         }
 
@@ -175,12 +176,12 @@ module.exports = function (fields, options) {
                     dayPart, monthPart, yearPart;
 
                 if (isExact) {
-                    dayPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-day', { pattern: '[0-9]*', min: 1, max: 31, maxlength: 2, hintId: key + '-hint' }));
+                    dayPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-day', { pattern: '[0-9]*', min: 1, max: 31, maxlength: 2, hintId: key + '-hint', date: true }));
                     parts.push(dayPart);
                 }
 
-                monthPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-month', { pattern: '[0-9]*', min: 1, max: 12, maxlength: 2, hintId: key + '-hint' }));
-                yearPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-year', { pattern: '[0-9]*', maxlength: 4, hintId: key + '-hint' }));
+                monthPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-month', { pattern: '[0-9]*', min: 1, max: 12, maxlength: 2, hintId: key + '-hint', date: true }));
+                yearPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-year', { pattern: '[0-9]*', maxlength: 4, hintId: key + '-hint', date: true }));
                 parts = parts.concat(monthPart, yearPart);
 
                 return parts.join('\n');

--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -1,9 +1,9 @@
-<div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
+<div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{^date}}{{#error}} validation-error{{/error}}{{/date}}">
     <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">
-        {{#error}}<span class="error-message" aria-hidden="true">{{error.message}}</span>{{/error}}
+        {{^date}}{{#error}}<span class="error-message" aria-hidden="true">{{error.message}}</span>{{/error}}{{/date}}
         {{{label}}}
         {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="form-hint">{{hint}}</span>{{/hint}}
-        {{#error}}<span class="visuallyhidden">{{error.message}}</span>{{/error}}
+        {{^date}}{{#error}}<span class="visuallyhidden">{{error.message}}</span>{{/error}}{{/date}}
     </label>
     <input
         type="{{type}}"

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -189,15 +189,15 @@ describe('Template Mixins', function () {
                     yearCall = render.getCall(2);
 
                 dayCall.should.have.been.calledWith(sinon.match({
-                  label: 'fields.field-name-day.label'
+                    label: 'fields.field-name-day.label'
                 }));
 
                 monthCall.should.have.been.calledWith(sinon.match({
-                  label: 'fields.field-name-month.label'
+                    label: 'fields.field-name-month.label'
                 }));
 
                 yearCall.should.have.been.calledWith(sinon.match({
-                  label: 'fields.field-name-year.label'
+                    label: 'fields.field-name-year.label'
                 }));
             });
 
@@ -213,15 +213,30 @@ describe('Template Mixins', function () {
                     yearCall = render.getCall(2);
 
                 dayCall.should.have.been.calledWith(sinon.match({
-                  label: 'name.space.fields.field-name-day.label'
+                    label: 'name.space.fields.field-name-day.label'
                 }));
 
                 monthCall.should.have.been.calledWith(sinon.match({
-                  label: 'name.space.fields.field-name-month.label'
+                    label: 'name.space.fields.field-name-month.label'
                 }));
 
                 yearCall.should.have.been.calledWith(sinon.match({
-                  label: 'name.space.fields.field-name-year.label'
+                    label: 'name.space.fields.field-name-year.label'
+                }));
+            });
+
+            it('sets a date boolean to conditionally show input errors', function () {
+                middleware(req, res, next);
+                res.locals['input-date']().call(res.locals, 'field-name');
+
+                render.getCall(0).should.have.been.calledWithExactly(sinon.match({
+                    date: true
+                }));
+                render.getCall(1).should.have.been.calledWithExactly(sinon.match({
+                    date: true
+                }));
+                render.getCall(2).should.have.been.calledWithExactly(sinon.match({
+                    date: true
                 }));
             });
 


### PR DESCRIPTION
When input fields are part of a date group we only want to show validation error messages at a fieldset level but want to apply error styling and add the `aria-invalid` attribute at individual field level.

Pass a `date` attribute to the `inputText` function from the `input-date` mixin, which is then used to hide error message in the input label.

Test that a date boolean is passed to Hogan's render method as part of the `input-date` mixin.