### PR TITLE
Label classes

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -59,17 +59,20 @@ module.exports = function (fields, options) {
         return fields[key] && fields[key].type || 'text';
     }
 
-    function classNameString(obj) {
-        if (_.isArray(obj.className)) {
-            return obj.className.join(' ');
+    function classNameString(name) {
+        if (_.isArray(name)) {
+            return name.join(' ');
         } else {
-            return obj.className;
+            return name;
         }
     }
 
-    function classNames(key) {
-        if (fields[key]) {
-            return classNameString(fields[key]);
+    function classNames(key, prop) {
+        prop = prop || 'className';
+        if (fields[key] && fields[key][prop]) {
+            return classNameString(fields[key][prop]);
+        } else {
+            return '';
         }
     }
 
@@ -97,6 +100,7 @@ module.exports = function (fields, options) {
                 type: extension.type || type(key),
                 value: this.values && this.values[key],
                 label: t(fieldLabel || 'fields.' + key + '.label'),
+                labelClassName: classNames(key, 'labelClassName') || 'form-label-bold',
                 hint: hint,
                 hintId: extension.hintId || (hint ? key + '-hint' : null),
                 error: this.errors && this.errors[key],
@@ -109,7 +113,7 @@ module.exports = function (fields, options) {
 
         function optionGroup(key) {
             var legendClassName = fields[key] && fields[key].legend;
-            if (legendClassName) { legendClassName = classNameString(legendClassName); }
+            if (legendClassName) { legendClassName = classNameString(legendClassName.className); }
             return {
                 'key': key,
                 'error': this.errors && this.errors[key],

--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -1,5 +1,5 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{^date}}{{#error}} validation-error{{/error}}{{/date}}">
-    <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">
+    <label for="{{id}}" class="{{labelClassName}}{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">
         {{^date}}{{#error}}<span class="error-message" aria-hidden="true">{{error.message}}</span>{{/error}}{{/date}}
         {{{label}}}
         {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="form-hint">{{hint}}</span>{{/hint}}

--- a/partials/forms/select.html
+++ b/partials/forms/select.html
@@ -1,5 +1,5 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
-    <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">{{label}}</label>
+    <label for="{{id}}" class="{{labelClassName}}{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">{{label}}</label>
     <select id="{{id}}" class="{{#class}}{{class}}{{/class}}{{#error}} invalid-input{{/error}}" name="{{id}}" aria-required="{{required}}">
     {{#options}}
         <option value="{{value}}" {{#selected}}selected{{/selected}}>{{label}}</option>

--- a/partials/forms/textarea-group.html
+++ b/partials/forms/textarea-group.html
@@ -1,5 +1,5 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
-    <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">
+    <label for="{{id}}" class="{{labelClassName}}{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">
         {{#error}}<span class="error-message" aria-hidden="true">{{error.message}}</span>{{/error}}
         {{{label}}}
         {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="form-hint">{{hint}}</span>{{/hint}}

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -143,6 +143,43 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('sets `labelClassName` to "form-label-bold" by default', function () {
+                middleware = mixins({
+                    'field-name': {}
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'form-label-bold'
+                }));
+            });
+
+            it('overrides `labelClassName` when set in field options', function () {
+                middleware = mixins({
+                    'field-name': {
+                        labelClassName: 'visuallyhidden'
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'visuallyhidden'
+                }));
+            });
+
+            it('sets all classes of `labelClassName` option', function () {
+                middleware = mixins({
+                    'field-name': {
+                        labelClassName: ['abc', 'def']
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'abc def'
+                }));
+            });
+
         });
 
         describe('input-date', function () {
@@ -360,6 +397,43 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('sets `labelClassName` to "form-label-bold" by default', function () {
+                middleware = mixins({
+                    'field-name': {}
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['textarea']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'form-label-bold'
+                }));
+            });
+
+            it('overrides `labelClassName` when set in field options', function () {
+                middleware = mixins({
+                    'field-name': {
+                        'labelClassName': 'visuallyhidden'
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['textarea']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'visuallyhidden'
+                }));
+            });
+
+            it('sets all classes of `labelClassName` option', function () {
+                middleware = mixins({
+                    'field-name': {
+                        labelClassName: ['abc', 'def']
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['textarea']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'abc def'
+                }));
+            });
+
         });
 
         describe('checkbox', function () {
@@ -509,6 +583,60 @@ describe('Template Mixins', function () {
                 }));
             });
 
+        });
+
+        describe('select', function () {
+
+            beforeEach(function () {
+                middleware = mixins({}, { translate: translate });
+            });
+
+            it('adds a function to res.locals', function () {
+                middleware(req, res, next);
+                res.locals['select'].should.be.a('function');
+            });
+
+            it('returns a function', function () {
+                middleware(req, res, next);
+                res.locals['select']().should.be.a('function');
+            });
+
+            it('defaults `labelClassName` to "form-label-bold"', function () {
+                middleware = mixins({
+                    'field-name': {}
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['select']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'form-label-bold'
+                }));
+            });
+
+            it('overrides `labelClassName` when set in field options', function () {
+                middleware = mixins({
+                    'field-name': {
+                        labelClassName: 'visuallyhidden'
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['select']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'visuallyhidden'
+                }));
+            });
+
+            it('sets all classes of `labelClassName` option', function () {
+                middleware = mixins({
+                    'field-name': {
+                        labelClassName: ['abc', 'def']
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['select']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'abc def'
+                }));
+            });
         });
 
     });


### PR DESCRIPTION
Allow a configurable className for labels in input groups, textarea groups and select boxes as the field option `labelClassName`. This follows a similar pattern to `legendClassName` and defaults to "form-label-bold".

This is a non-breaking change.