### PR TITLE
Custom textarea attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ select
 input-text
 input-date
 input-text-compound
-input-text-hidden-label
 input-text-code
 input-phone
 radio-group

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -59,17 +59,20 @@ module.exports = function (fields, options) {
         return fields[key] && fields[key].type || 'text';
     }
 
-    function classNameString(obj) {
-        if (_.isArray(obj.className)) {
-            return obj.className.join(' ');
+    function classNameString(name) {
+        if (_.isArray(name)) {
+            return name.join(' ');
         } else {
-            return obj.className;
+            return name;
         }
     }
 
-    function classNames(key) {
-        if (fields[key]) {
-            return classNameString(fields[key]);
+    function classNames(key, prop) {
+        prop = prop || 'className';
+        if (fields[key] && fields[key][prop]) {
+            return classNameString(fields[key][prop]);
+        } else {
+            return '';
         }
     }
 
@@ -97,6 +100,7 @@ module.exports = function (fields, options) {
                 type: extension.type || type(key),
                 value: this.values && this.values[key],
                 label: t(fieldLabel || 'fields.' + key + '.label'),
+                labelClassName: classNames(key, 'labelClassName') || 'form-label-bold',
                 hint: hint,
                 hintId: extension.hintId || (hint ? key + '-hint' : null),
                 error: this.errors && this.errors[key],
@@ -109,7 +113,7 @@ module.exports = function (fields, options) {
 
         function optionGroup(key) {
             var legendClassName = fields[key] && fields[key].legend;
-            if (legendClassName) { legendClassName = classNameString(legendClassName); }
+            if (legendClassName) { legendClassName = classNameString(legendClassName.className); }
             return {
                 'key': key,
                 'error': this.errors && this.errors[key],

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -105,7 +105,7 @@ module.exports = function (fields, options) {
                 hintId: extension.hintId || (hint ? key + '-hint' : null),
                 error: this.errors && this.errors[key],
                 maxlength: maxlength(key) || extension.maxlength,
-                required: extension.required !== undefined ? extension.required : true,
+                required: fields[key] && fields[key].required !== undefined ? fields[key].required : true,
                 pattern: extension.pattern,
                 date: extension.date
             });
@@ -195,16 +195,6 @@ module.exports = function (fields, options) {
         res.locals['input-text-compound'] = function () {
             return function (key) {
                 var obj = { compound: true };
-                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, obj));
-            };
-        };
-
-        res.locals['input-text-hidden-label'] = function () {
-            return function (key) {
-                var obj = {
-                    hiddenLabel: true,
-                    required: false
-                };
                 return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, obj));
             };
         };

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -107,7 +107,8 @@ module.exports = function (fields, options) {
                 maxlength: maxlength(key) || extension.maxlength,
                 required: fields[key] && fields[key].required !== undefined ? fields[key].required : true,
                 pattern: extension.pattern,
-                date: extension.date
+                date: extension.date,
+                attributes: fields[key] && fields[key].attributes
             });
         }
 

--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -1,5 +1,5 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{^date}}{{#error}} validation-error{{/error}}{{/date}}">
-    <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">
+    <label for="{{id}}" class="{{labelClassName}}{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">
         {{^date}}{{#error}}<span class="error-message" aria-hidden="true">{{error.message}}</span>{{/error}}{{/date}}
         {{{label}}}
         {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="form-hint">{{hint}}</span>{{/hint}}

--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -1,5 +1,5 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{^date}}{{#error}} validation-error{{/error}}{{/date}}">
-    <label for="{{id}}" class="{{labelClassName}}{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">
+    <label for="{{id}}" class="{{labelClassName}}">
         {{^date}}{{#error}}<span class="error-message" aria-hidden="true">{{error.message}}</span>{{/error}}{{/date}}
         {{{label}}}
         {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="form-hint">{{hint}}</span>{{/hint}}

--- a/partials/forms/select.html
+++ b/partials/forms/select.html
@@ -1,5 +1,5 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
-    <label for="{{id}}" class="{{labelClassName}}{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">{{label}}</label>
+    <label for="{{id}}" class="{{labelClassName}}}">{{label}}</label>
     <select id="{{id}}" class="{{#class}}{{class}}{{/class}}{{#error}} invalid-input{{/error}}" name="{{id}}" aria-required="{{required}}">
     {{#options}}
         <option value="{{value}}" {{#selected}}selected{{/selected}}>{{label}}</option>

--- a/partials/forms/select.html
+++ b/partials/forms/select.html
@@ -1,5 +1,5 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
-    <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">{{label}}</label>
+    <label for="{{id}}" class="{{labelClassName}}{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">{{label}}</label>
     <select id="{{id}}" class="{{#class}}{{class}}{{/class}}{{#error}} invalid-input{{/error}}" name="{{id}}" aria-required="{{required}}">
     {{#options}}
         <option value="{{value}}" {{#selected}}selected{{/selected}}>{{label}}</option>

--- a/partials/forms/textarea-group.html
+++ b/partials/forms/textarea-group.html
@@ -11,6 +11,9 @@
         class="form-control{{#className}} {{className}}{{/className}}{{#error}} invalid-input{{/error}}"
         aria-required="{{required}}"
         {{#maxlength}} maxlength="{{maxlength}}"{{/maxlength}}
+        {{#attributes}}
+            {{attribute}}="{{value}}"
+        {{/attributes}}
         {{#hintId}} aria-describedby="{{hintId}}"{{/hintId}}
         {{#error}} aria-invalid="true"{{/error}}
     >{{value}}</textarea>

--- a/partials/forms/textarea-group.html
+++ b/partials/forms/textarea-group.html
@@ -1,5 +1,5 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
-    <label for="{{id}}" class="form-label-bold{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">
+    <label for="{{id}}" class="{{labelClassName}}{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">
         {{#error}}<span class="error-message" aria-hidden="true">{{error.message}}</span>{{/error}}
         {{{label}}}
         {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="form-hint">{{hint}}</span>{{/hint}}

--- a/partials/forms/textarea-group.html
+++ b/partials/forms/textarea-group.html
@@ -1,5 +1,5 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
-    <label for="{{id}}" class="{{labelClassName}}{{#hiddenLabel}} visuallyhidden{{/hiddenLabel}}">
+    <label for="{{id}}" class="{{labelClassName}}">
         {{#error}}<span class="error-message" aria-hidden="true">{{error.message}}</span>{{/error}}
         {{{label}}}
         {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="form-hint">{{hint}}</span>{{/hint}}

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -449,6 +449,25 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('sets additional element attributes', function () {
+                middleware = mixins({
+                    'field-name': {
+                        attributes: [
+                            { attribute: 'spellcheck', value: 'true' },
+                            { attribute: 'autocapitalize', value: 'sentences' }
+                        ]
+                    }
+                });
+                middleware(req, res, next);
+                res.locals['textarea']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    attributes: [
+                        { attribute: 'spellcheck', value: 'true' },
+                        { attribute: 'autocapitalize', value: 'sentences' }
+                    ]
+                }));
+            });
+
         });
 
         describe('checkbox', function () {

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -143,6 +143,43 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('sets `labelClassName` to "form-label-bold" by default', function () {
+                middleware = mixins({
+                    'field-name': {}
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'form-label-bold'
+                }));
+            });
+
+            it('overrides `labelClassName` when set in field options', function () {
+                middleware = mixins({
+                    'field-name': {
+                        labelClassName: 'visuallyhidden'
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'visuallyhidden'
+                }));
+            });
+
+            it('sets all classes of `labelClassName` option', function () {
+                middleware = mixins({
+                    'field-name': {
+                        labelClassName: ['abc', 'def']
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'abc def'
+                }));
+            });
+
         });
 
         describe('input-date', function () {
@@ -360,6 +397,43 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('sets `labelClassName` to "form-label-bold" by default', function () {
+                middleware = mixins({
+                    'field-name': {}
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['textarea']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'form-label-bold'
+                }));
+            });
+
+            it('overrides `labelClassName` when set in field options', function () {
+                middleware = mixins({
+                    'field-name': {
+                        'labelClassName': 'visuallyhidden'
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['textarea']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'visuallyhidden'
+                }));
+            });
+
+            it('sets all classes of `labelClassName` option', function () {
+                middleware = mixins({
+                    'field-name': {
+                        labelClassName: ['abc', 'def']
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['textarea']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'abc def'
+                }));
+            });
+
         });
 
         describe('checkbox', function () {
@@ -509,6 +583,60 @@ describe('Template Mixins', function () {
                 }));
             });
 
+        });
+
+        describe('select', function () {
+
+            beforeEach(function () {
+                middleware = mixins({}, { translate: translate });
+            });
+
+            it('adds a function to res.locals', function () {
+                middleware(req, res, next);
+                res.locals['select'].should.be.a('function');
+            });
+
+            it('returns a function', function () {
+                middleware(req, res, next);
+                res.locals['select']().should.be.a('function');
+            });
+
+            it('defaults `labelClassName` to "form-label-bold"', function () {
+                middleware = mixins({
+                    'field-name': {}
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['select']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'form-label-bold'
+                }));
+            });
+
+            it('overrides `labelClassName` when set in field options', function () {
+                middleware = mixins({
+                    'field-name': {
+                        labelClassName: 'visuallyhidden'
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['select']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'visuallyhidden'
+                }));
+            });
+
+            it('sets all classes of `labelClassName` option', function () {
+                middleware = mixins({
+                    'field-name': {
+                        labelClassName: ['abc', 'def']
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['select']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    labelClassName: 'abc def'
+                }));
+            });
         });
 
     });

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -180,6 +180,21 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('allows configuration of a non-required input with a visuallyhidden label', function () {
+                middleware = mixins({
+                    'field-name': {
+                        required: false,
+                        labelClassName: 'visuallyhidden'
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    required: false,
+                    labelClassName: 'visuallyhidden'
+                }));
+            });
+
         });
 
         describe('input-date', function () {


### PR DESCRIPTION
Allow additional element attributes to be set on textareas.

This builds on #34 and would be a non-breaking change.