### PR TITLE
Add an `input-number` mixin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ input-date
 input-text-compound
 input-text-hidden-label
 input-text-code
+input-number
 input-phone
 radio-group
 checkbox

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -211,6 +211,12 @@ module.exports = function (fields, options) {
             };
         };
 
+        res.locals['input-number'] = function () {
+            return function (key) {
+                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, { pattern: '[0-9]*' }));
+            };
+        };
+
         res.locals['input-phone'] = function () {
             return function (key) {
                 return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, { maxlength: 18 }));

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -242,6 +242,32 @@ describe('Template Mixins', function () {
 
         });
 
+        describe('input-number', function () {
+
+            beforeEach(function () {
+                middleware = mixins({}, { translate: translate });
+            });
+
+            it('adds a function to res.locals', function () {
+                middleware(req, res, next);
+                res.locals['input-number'].should.be.a('function');
+            });
+
+            it('returns a function', function () {
+                middleware(req, res, next);
+                res.locals['input-number']().should.be.a('function');
+            });
+
+            it('adds a pattern attribute to trigger the number keypad on mobile devices', function () {
+                middleware(req, res, next);
+                res.locals['input-number']().call(res.locals, 'field-name');
+                render.should.have.been.calledWithExactly(sinon.match({
+                    pattern: '[0-9]*'
+                }));
+            });
+
+        });
+
         describe('input-submit', function () {
 
             beforeEach(function () {


### PR DESCRIPTION
The field type remains as 'text' but a regex number pattern is used to trigger the number keypad on mobile devices. There is a number input type but the native browser controls haven't tested well in user research sessions at GDS.