### PR TITLE
Option Group Legends

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -118,8 +118,9 @@ module.exports = function (fields, options) {
             return {
                 'key': key,
                 'error': this.errors && this.errors[key],
-                'legend': fields[key] && fields[key].legend && fields[key].legend.value,
+                'legend': fields[key] && fields[key].legend && fields[key].legend.value || t('fields.' + key + '.legend'),
                 'legendClassName': legendClassName,
+                hint: conditionaltranslate('fields.' + key + '.hint'),
                 'options': _.map(fields[key] && fields[key].options, function (obj) {
                     var selected = false, label, value, toggle;
 

--- a/partials/forms/radio-group.html
+++ b/partials/forms/radio-group.html
@@ -2,6 +2,7 @@
     <legend>
         {{#error}}<span id="{{key}}-error" class="error-message">{{error.message}}</span>{{/error}}
         <span{{#legendClassName}} class="{{legendClassName}}"{{/legendClassName}}>{{legend}}</span>
+        {{#hint}}<span id="{{key}}-hint" class="form-hint">{{hint}}</span>{{/hint}}
     </legend>
     {{#options}}
         <label class="block-label" for="{{key}}-{{value}}">
@@ -13,6 +14,7 @@
                 aria-required="true"
                 {{#toggle}} data-toggle="{{toggle}}"{{/toggle}}
                 {{#selected}} checked="checked"{{/selected}}
+                {{^error}}{{#hint}} aria-describedby="{{key}}-hint"{{/hint}}{{/error}}
                 {{#error}} aria-describedby="{{key}}-error" aria-invalid="true"{{/error}}
             >
             {{{label}}}

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -643,6 +643,41 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('uses locales translation for legend if a field value isn\'t provided', function () {
+                translate = sinon.stub().withArgs('fields.field-name.legend').returns('Field legend');
+                middleware = mixins({
+                    'field-name': {}
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['radio-group']().call(res.locals, 'field-name');
+                render.should.have.been.calledWithExactly(sinon.match({
+                    legend: 'Field legend'
+                }));
+            });
+
+            it('adds a hint if it exists in locales', function () {
+                translate = sinon.stub().withArgs('field.field-name.hint').returns('Field hint');
+                middleware = mixins({
+                    'field-name': {}
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['radio-group']().call(res.locals, 'field-name');
+                render.should.have.been.calledWithExactly(sinon.match({
+                    hint: 'Field hint'
+                }));
+            });
+
+            it('doesn\'t add a hint if the hint doesn\'t exist in locales', function () {
+                middleware = mixins({
+                    'field-name': {}
+                });
+                middleware(req, res, next);
+                res.locals['radio-group']().call(res.locals, 'field-name');
+                render.should.have.been.calledWithExactly(sinon.match({
+                    hint: null
+                }));
+            });
+
         });
 
         describe('select', function () {


### PR DESCRIPTION
Allow option group legends to be set in translation files. Also enable this for optional hint text.

This is a non-breaking change.