### PR TITLE
Allow attributes to be set on input-text-group

### DIFF
--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -18,5 +18,8 @@
         {{#pattern}} pattern="{{pattern}}"{{/pattern}}
         {{#hintId}} aria-describedby="{{hintId}}"{{/hintId}}
         {{#error}} aria-invalid="true"{{/error}}
+        {{#attributes}}
+            {{attribute}}="{{value}}"
+        {{/attributes}}
     >
 </div>

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -180,6 +180,23 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('sets additional element attributes', function () {
+                middleware = mixins({
+                    'field-name': {
+                        attributes: [
+                            { attribute: 'autocomplete', value: 'true' }
+                        ]
+                    }
+                });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    attributes: [
+                        { attribute: 'autocomplete', value: 'true' }
+                    ]
+                }));
+            });
+
             it('allows configuration of a non-required input with a visuallyhidden label', function () {
                 middleware = mixins({
                     'field-name': {


### PR DESCRIPTION
Allow for *any* attribute to get set on `input-text-group` through the attributes pattern currently used in textarea.

This could be used for say: 
```
{
  attributes: [{
    attribute: 'autocomplete',
    value: true
  }]
}
```

