### PR TITLE
If an option label translation is returned as `undefined` set it as an empty string.

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -147,7 +147,7 @@ module.exports = function (fields, options) {
                     }
 
                     return {
-                        label: t(label),
+                        label: t(label) || '',
                         value: value,
                         selected: selected,
                         toggle: toggle

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -749,6 +749,24 @@ describe('Template Mixins', function () {
                     labelClassName: 'abc def'
                 }));
             });
+
+            it('sets labels to an empty string for translations that are returned as `undefined`', function () {
+                var translate = sinon.stub().returns(undefined);
+                middleware = mixins({
+                    'field-name': {
+                        options: [
+                            ''
+                        ]
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['select']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    options: [
+                        { label: '', selected: false, toggle: undefined, value: '' }
+                    ]
+                }));
+            });
         });
 
     });


### PR DESCRIPTION
@easternbloc @JoeChapman 