### PR TITLE
Treat labels and hints the same

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -92,7 +92,7 @@ module.exports = function (fields, options) {
         };
 
         var getTranslationKey = function (key, property) {
-            return fields && fields[key] ? fields[key][property] : 'fields.' + key + '.' + property;
+            return fields && fields[key] && fields[key][property] ? fields[key][property] : 'fields.' + key + '.' + property;
         };
 
         function inputText(key, extension) {

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -84,22 +84,30 @@ module.exports = function (fields, options) {
             return translate(sharedTranslationsKey + key);
         };
 
-        var conditionaltranslate = function (key) {
+        // Like t() but returns null on failed translations
+        var conditionalTranslate = function (key) {
             key = sharedTranslationsKey + key;
             var translated = translate(key);
             return translated !== key ? translated : null;
         };
 
+        var getTranslationKey = function (key, property) {
+            return fields && fields[key] ? fields[key][property] : 'fields.' + key + '.' + property;
+        };
+
         function inputText(key, extension) {
+            var hKey = getTranslationKey(key, 'hint');
+            var lKey = getTranslationKey(key, 'label');
+            var hint = conditionalTranslate(hKey);
+
             extension = extension || {};
-            var hint = conditionaltranslate('fields.' + key + '.hint');
-            var fieldLabel = fields && fields[key] ? fields[key].label : false;
+
             return _.extend(extension, {
                 id: key,
                 className: extension.className || classNames(key),
                 type: extension.type || type(key),
                 value: this.values && this.values[key],
-                label: t(fieldLabel || 'fields.' + key + '.label'),
+                label: t(lKey),
                 labelClassName: classNames(key, 'labelClassName') || 'form-label-bold',
                 hint: hint,
                 hintId: extension.hintId || (hint ? key + '-hint' : null),
@@ -129,7 +137,7 @@ module.exports = function (fields, options) {
                 'error': this.errors && this.errors[key],
                 'legend': t(legendValue),
                 'legendClassName': legendClassName,
-                hint: conditionaltranslate('fields.' + key + '.hint'),
+                hint: conditionalTranslate(getTranslationKey(key, 'hint')),
                 'options': _.map(fields[key] && fields[key].options, function (obj) {
                     var selected = false, label, value, toggle;
 

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -65,6 +65,18 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('looks up default field label if nothing is set', function () {
+                middleware = mixins({
+                    'field-name': {
+                    }
+                });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    label: 'fields.field-name.label'
+                }));
+            });
+
             it('prefixes translation lookup with namespace if provided', function () {
                 middleware = mixins({}, { translate: translate, sharedTranslationsKey: 'name.space' });
                 middleware(req, res, next);

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -710,6 +710,18 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('uses locales translation for hint if a field value isn\'t provided', function () {
+                translate = sinon.stub().withArgs('fields.field-name.hint').returns('Field hint');
+                middleware = mixins({
+                    'field-name': {}
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['radio-group']().call(res.locals, 'field-name');
+                render.should.have.been.calledWithExactly(sinon.match({
+                    hint: 'Field hint'
+                }));
+            });
+
             it('adds a hint if it exists in locales', function () {
                 translate = sinon.stub().withArgs('field.field-name.hint').returns('Field hint');
                 middleware = mixins({

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -141,7 +141,7 @@ describe('Template Mixins', function () {
                 }));
             });
 
-            it('includes a hint if it is defined in the locals', function () {
+            it('includes a hint if it is defined in the locales', function () {
                 var translate = sinon.stub().withArgs('field-name.hint').returns('Field hint');
                 middleware = mixins({
                     'field-name': {

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -77,6 +77,19 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('uses label when available for the field', function () {
+                middleware = mixins({
+                    'field-name': {
+                        label: 'Label text'
+                    }
+                });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    label: 'Label text'
+                }));
+            });
+
             it('prefixes translation lookup with namespace if provided', function () {
                 middleware = mixins({}, { translate: translate, sharedTranslationsKey: 'name.space' });
                 middleware(req, res, next);
@@ -128,11 +141,24 @@ describe('Template Mixins', function () {
                 }));
             });
 
-            it('includes a hint if it is defined in translation', function () {
-                var translate = sinon.stub().withArgs({'label': 'field-name.hint'}).returns('Field hint');
+            it('includes a hint if it is defined in the locals', function () {
+                var translate = sinon.stub().withArgs({'hint': 'field-name.hint'}).returns('Field hint');
                 middleware = mixins({
                     'field-name': {
-                        'label': 'field-name.label'
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    hint: 'Field hint'
+                }));
+            });
+
+            it('includes a hint if it is defined in translation', function () {
+                var translate = sinon.stub().withArgs({'hint': 'field-name.hint'}).returns('Field hint');
+                middleware = mixins({
+                    'field-name': {
+                        'hint': 'field-name.hint'
                     }
                 }, { translate: translate });
                 middleware(req, res, next);
@@ -145,7 +171,7 @@ describe('Template Mixins', function () {
             it('does not include a hint if it is not defined in translation', function () {
                 middleware = mixins({
                     'field-name': {
-                        'label': 'field-name.label'
+                        'hint': 'field-name.hint'
                     }
                 }, { translate: translate });
                 middleware(req, res, next);

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -722,18 +722,6 @@ describe('Template Mixins', function () {
                 }));
             });
 
-            it('adds a hint if it exists in locales', function () {
-                translate = sinon.stub().withArgs('field.field-name.hint').returns('Field hint');
-                middleware = mixins({
-                    'field-name': {}
-                }, { translate: translate });
-                middleware(req, res, next);
-                res.locals['radio-group']().call(res.locals, 'field-name');
-                render.should.have.been.calledWithExactly(sinon.match({
-                    hint: 'Field hint'
-                }));
-            });
-
             it('doesn\'t add a hint if the hint doesn\'t exist in locales', function () {
                 middleware = mixins({
                     'field-name': {}

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -128,7 +128,7 @@ describe('Template Mixins', function () {
             });
 
             it('uses locales translation property', function () {
-                var translate = sinon.stub().withArgs({'label': 'field-name.label'}).returns('Field name');
+                var translate = sinon.stub().withArgs('field-name.label').returns('Field name');
                 middleware = mixins({
                     'field-name': {
                         'label': 'field-name.label'
@@ -142,7 +142,7 @@ describe('Template Mixins', function () {
             });
 
             it('includes a hint if it is defined in the locals', function () {
-                var translate = sinon.stub().withArgs({'hint': 'field-name.hint'}).returns('Field hint');
+                var translate = sinon.stub().withArgs('field-name.hint').returns('Field hint');
                 middleware = mixins({
                     'field-name': {
                     }
@@ -155,7 +155,7 @@ describe('Template Mixins', function () {
             });
 
             it('includes a hint if it is defined in translation', function () {
-                var translate = sinon.stub().withArgs({'hint': 'field-name.hint'}).returns('Field hint');
+                var translate = sinon.stub().withArgs('field-name.hint').returns('Field hint');
                 middleware = mixins({
                     'field-name': {
                         'hint': 'field-name.hint'
@@ -480,7 +480,7 @@ describe('Template Mixins', function () {
             });
 
             it('uses locales translation property', function () {
-                var translate = sinon.stub().withArgs({'label': 'field-name.label'}).returns('Field name');
+                var translate = sinon.stub().withArgs('field-name.label').returns('Field name');
                 middleware = mixins({
                     'field-name': {
                         'label': 'field-name.label'
@@ -585,7 +585,7 @@ describe('Template Mixins', function () {
             });
 
             it('uses locales translation property', function () {
-                var translate = sinon.stub().withArgs({'label': 'field-name.label'}).returns('Field name');
+                var translate = sinon.stub().withArgs('field-name.label').returns('Field name');
                 middleware = mixins({
                     'field-name': {
                         'label': 'field-name.label'


### PR DESCRIPTION
Translations for labels and hints on inputText and optionGroup were
handled differently. This commit brings them into alignment and makes
the symmetry clear.

Also renames conditionaltranslate to conditionalTranslate.