### PR TITLE
Only set aria-required to true on mandatory fields

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -100,6 +100,22 @@ module.exports = function (fields, options) {
             var lKey = getTranslationKey(key, 'label');
             var hint = conditionalTranslate(hKey);
 
+            var required = function isRequired() {
+              var r = false;
+
+              if (fields[key]) {
+                if (fields[key].required !== undefined) {
+                  return fields[key].required;
+                } else if (fields[key].validate) {
+                  var hasRequiredValidator = _.indexOf(fields[key].validate, 'required') !== -1;
+
+                  return hasRequiredValidator ? true : false;
+                }
+              }
+
+              return r;
+            }();
+
             extension = extension || {};
 
             return _.extend(extension, {
@@ -113,7 +129,7 @@ module.exports = function (fields, options) {
                 hintId: extension.hintId || (hint ? key + '-hint' : null),
                 error: this.errors && this.errors[key],
                 maxlength: maxlength(key) || extension.maxlength,
-                required: fields[key] && fields[key].required !== undefined ? fields[key].required : true,
+                required: required,
                 pattern: extension.pattern,
                 date: extension.date,
                 attributes: fields[key] && fields[key].attributes

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -250,6 +250,57 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('by default, assumes the field isn\'t required', function () {
+                middleware = mixins({
+                    'field-name': {}
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    required: false
+                }));
+            });
+
+            it('allows configuration of required status with the required property', function () {
+                middleware = mixins({
+                    'field-name': {
+                        required: true
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    required: true
+                }));
+            });
+
+            it('allows configuration of required status with the required validator', function () {
+                middleware = mixins({
+                    'field-name': {
+                        validate: ['required']
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    required: true
+                }));
+            });
+
+            it('the required property takes precedence over the required validator', function () {
+                middleware = mixins({
+                    'field-name': {
+                        required: false,
+                        validate: ['required']
+                    }
+                }, { translate: translate });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    required: false
+                }));
+            });
+
         });
 
         describe('input-date', function () {


### PR DESCRIPTION
This commit changes behaviour to only set aria-required to true, when
the field is set to mandatory, either by setting the 'required' property
or by setting the 'required' validator.