### PR TITLE
Fix url path for apps that are not mounted on a sub-path

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -386,7 +386,7 @@ module.exports = function (fields, options) {
         res.locals.url = function () {
             return function (url) {
                 url = Hogan.compile(url).render(this);
-                return path.resolve(req.baseUrl, url);
+                return req.baseUrl ? path.resolve(req.baseUrl, url) : url;
             };
         };
 

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -973,6 +973,13 @@ describe('Template Mixins', function () {
                 res.locals.url().call(res.locals, 'path').should.equal('/base/path');
             });
 
+            it('returns path if baseUrl is not set', function () {
+                req.baseUrl = undefined;
+                middleware(req, res, next);
+                res.locals.url().call(res.locals, 'path').should.equal('path');
+                res.locals.url().call(res.locals, './path').should.equal('./path');
+            });
+
             it('does not prepend the baseUrl to absolute paths', function () {
                 req.baseUrl = '/base';
                 middleware(req, res, next);


### PR DESCRIPTION
Currently the url function assumes that req.baseUrl is set. For apps that are not mounted on a sub-path this may not be the case, which can result in the full location of the path on the server being returned for relative urls. This change just adds a check to see if req.baseUrl is set.