### PR TITLE
Allow the user to just overwrite some local partials

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -21,7 +21,7 @@ module.exports = function (fields, options) {
     fields = fields || {};
     options = options || {};
 
-    var viewsDirectory = options.viewsDirectory || path.resolve(__dirname, '../');
+    var viewsDirectory = path.resolve(__dirname, '../');
     var viewEngine = options.viewEngine || 'html';
     var sharedTranslationsKey = options.sharedTranslationsKey || '';
 
@@ -39,7 +39,15 @@ module.exports = function (fields, options) {
     ];
     var compiled = _.chain(PARTIALS).map(function (relativeTemplatePath) {
         var viewExtension = '.' + viewEngine;
-        var templatePath = path.join(viewsDirectory, relativeTemplatePath + viewExtension);
+        var templatePath;
+
+        try {
+            fs.statSync(path.join(options.viewsDirectory, relativeTemplatePath + viewExtension)).isFile();
+            templatePath = path.join(options.viewsDirectory, relativeTemplatePath + viewExtension);
+        } catch (e) {
+            templatePath = path.join(viewsDirectory, relativeTemplatePath + viewExtension);
+        }
+
         var compiledTemplate = Hogan.compile(fs.readFileSync(templatePath).toString());
 
         return [relativeTemplatePath, compiledTemplate];


### PR DESCRIPTION
Sometimes you want your own partials for some things and to use the default ones for others.

Presently if you specify a local viewDir and you don't have the partial required template-mixins will throw an error.

It'd be nice if it just used the local partial instead.