### PR TITLE
Added a renderChild lambda for use in radio-group mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,4 @@ textarea
 - `legendClassName`: Applied as a class name to HTML `legend` attribute.
 - `toggle`: Can be used to toggle the display of the HTML element with a matching `id`. See [passports-frontend-toolkit](https://github.com/UKHomeOffice/passports-frontend-toolkit/blob/master/assets/javascript/progressive-reveal.js) for details.
 - `attributes`: A hash of key/value pairs applicable to a HTML `textarea` field. Each key/value is assigned as an attribute of the `textarea`. For example `spellcheck="true"`.
+- `child`: Render a child partial beneath each option in an `optionGroup`. Accepts a custom mustache template string, a custom partial in the format `partials/{your-partial-name}` or a template mixin key which will be rendered within a panel element partial.

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -29,6 +29,8 @@ module.exports = function (fields, options) {
         sharedTranslationsKey += '.';
     }
 
+    var PANELMIXIN = 'partials/mixins/panel';
+
     var PARTIALS = [
         'partials/forms/input-text-group',
         'partials/forms/input-submit',
@@ -93,6 +95,45 @@ module.exports = function (fields, options) {
 
         var getTranslationKey = function (key, property) {
             return fields && fields[key] && fields[key][property] ? fields[key][property] : 'fields.' + key + '.' + property;
+        };
+
+        /*
+        * Utility function to parse {{x}} args passed to
+        * mustache lambda in a partial.
+        * Only the literal unparsed string including braces
+        * is available to lamba methods used in partials
+        * in this scope by default
+        */
+        var extractKey = function extractKey(key) {
+            // regex to extract x from {{x}}
+            var re = /^\{\{([^\{\}]+)\}\}$/;
+            var match = key.match(re);
+            // extract value and check scope for
+            // corresponding property
+            if (match && match[1] && this[match[1]]) {
+                key = this[match[1]];
+            }
+            return key;
+        };
+
+        /*
+         * helper function which takes a child string which
+         * can either be the name of a partial in the format
+         * partial/{partial-name}, the name of a template mixin
+         * or a raw template string to render
+         */
+        var getTemplate = function getTemplate(child) {
+            var re = /^partials\/(.+)/i;
+            var match = child.match(re);
+            if (match) {
+                res.locals.partials = res.locals.partials || {};
+                return fs.readFileSync(res.locals.partials['partials-' + match[1]] + '.' + viewEngine).toString();
+            } else if (res.locals[child]) {
+                var panelPath = path.join(viewsDirectory, PANELMIXIN + '.' + viewEngine);
+                return fs.readFileSync(panelPath).toString();
+            } else {
+                return child;
+            }
         };
 
         function inputText(key, extension) {
@@ -163,7 +204,7 @@ module.exports = function (fields, options) {
                 'legendClassName': legendClassName,
                 hint: conditionalTranslate(getTranslationKey(key, 'hint')),
                 'options': _.map(fields[key] && fields[key].options, function (obj) {
-                    var selected = false, label, value, toggle;
+                    var selected = false, label, value, toggle, child;
 
                     if (typeof obj === 'string') {
                         value = obj;
@@ -172,6 +213,7 @@ module.exports = function (fields, options) {
                         value = obj.value;
                         label = obj.label;
                         toggle = obj.toggle;
+                        child = obj.child;
                     }
 
                     if (this.values && this.values[key] !== undefined) {
@@ -182,10 +224,28 @@ module.exports = function (fields, options) {
                         label: t(label) || '',
                         value: value,
                         selected: selected,
-                        toggle: toggle
+                        toggle: toggle,
+                        child: child
                     };
                 }, this),
-                className: classNames(key)
+                className: classNames(key),
+                renderChild: function () {
+                    return function () {
+                        if (this.child) {
+                            var templateString = getTemplate(this.child, this.toggle);
+                            var template = Hogan.compile(templateString);
+                            return template.render(_.extend({
+                                renderMixin: function () {
+                                    return function () {
+                                        if (this.child && this[this.child]) {
+                                            return this[this.child]().call(this, this.toggle);
+                                        }
+                                    };
+                                }
+                            }, res.locals, this));
+                        }
+                    };
+                }
             };
         }
 
@@ -208,128 +268,144 @@ module.exports = function (fields, options) {
             });
         }
 
-        res.locals['input-text'] = function () {
-            return function (key) {
-                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key));
-            };
-        };
+        var mixins = {
+            'input-text': {
+                path: 'partials/forms/input-text-group',
+                renderWith: inputText
+            },
+            'input-text-compound': {
+                path: 'partials/forms/input-text-group',
+                renderWith: inputText,
+                options: {
+                    compound: true
+                }
+            },
+            'input-text-code': {
+                path: 'partials/forms/input-text-group',
+                renderWith: inputText,
+                options: {
+                    className: 'input-code'
+                }
+            },
+            'input-number': {
+                path: 'partials/forms/input-text-group',
+                renderWith: inputText,
+                options: {
+                    pattern: '[0-9]*'
+                }
+            },
+            'input-phone': {
+                path: 'partials/forms/input-text-group',
+                renderWith: inputText,
+                options: {
+                    maxlength: 18
+                }
+            },
+            textarea: {
+                path: 'partials/forms/textarea-group',
+                renderWith: inputText
+            },
+            'radio-group': {
+                path: 'partials/forms/radio-group',
+                renderWith: optionGroup
+            },
+            select: {
+                path: 'partials/forms/select',
+                renderWith: inputText,
+                options: optionGroup
+            },
+            checkbox: {
+                path: 'partials/forms/checkbox',
+                renderWith: checkbox
+            },
+            'checkbox-compound': {
+                path: 'partials/forms/checkbox',
+                renderWith: checkbox,
+                options: {
+                    compound: true
+                }
+            },
+            'checkbox-required': {
+                path: 'partials/forms/checkbox',
+                renderWith: checkbox,
+                options: {
+                    required: true
+                }
+            },
+            'input-submit': {
+                handler: function () {
+                    return function (props) {
+                        props = (props || '').split(' ');
+                        var def = 'next',
+                            value = props[0] || def,
+                            id = props[1];
 
-        res.locals['input-date'] = function () {
-            return function (key) {
-                // Exact unless there is a inexact property against the fields key.
-                var isExact = fields[key] ? fields[key].inexact !== true : true;
-
-                var autocomplete = fields[key] && fields[key].autocomplete || {};
-                if (autocomplete === 'off') {
-                    autocomplete = {
-                        day: 'off',
-                        month: 'off',
-                        year: 'off'
-                    };
-                } else if (typeof autocomplete === 'string') {
-                    autocomplete = {
-                        day: autocomplete + '-day',
-                        month: autocomplete + '-month',
-                        year: autocomplete + '-year'
+                        var obj = {
+                            value: t('buttons.' + value),
+                            id: id
+                        };
+                        return compiled['partials/forms/input-submit'].render(obj);
                     };
                 }
+            },
+            'input-date': {
+                handler: function () {
+                    /**
+                    * props: '[value] [id]'
+                    */
+                    return function (key) {
+                        key = extractKey(key);
+                        // Exact unless there is a inexact property against the fields key.
+                        var isExact = fields[key] ? fields[key].inexact !== true : true;
 
-                var parts = [],
-                    dayPart, monthPart, yearPart;
+                        var autocomplete = fields[key] && fields[key].autocomplete || {};
+                        if (autocomplete === 'off') {
+                            autocomplete = {
+                                day: 'off',
+                                month: 'off',
+                                year: 'off'
+                            };
+                        } else if (typeof autocomplete === 'string') {
+                            autocomplete = {
+                                day: autocomplete + '-day',
+                                month: autocomplete + '-month',
+                                year: autocomplete + '-year'
+                            };
+                        }
 
-                if (isExact) {
-                    dayPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-day', { pattern: '[0-9]*', min: 1, max: 31, maxlength: 2, hintId: key + '-hint', date: true, autocomplete: autocomplete.day }));
-                    parts.push(dayPart);
+                        var parts = [],
+                            dayPart, monthPart, yearPart;
+
+                        if (isExact) {
+                            dayPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-day', { pattern: '[0-9]*', min: 1, max: 31, maxlength: 2, hintId: key + '-hint', date: true, autocomplete: autocomplete.day }));
+                            parts.push(dayPart);
+                        }
+
+                        monthPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-month', { pattern: '[0-9]*', min: 1, max: 12, maxlength: 2, hintId: key + '-hint', date: true, autocomplete: autocomplete.month }));
+                        yearPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-year', { pattern: '[0-9]*', maxlength: 4, hintId: key + '-hint', date: true, autocomplete: autocomplete.year }));
+                        parts = parts.concat(monthPart, yearPart);
+
+                        return parts.join('\n');
+                    };
                 }
-
-                monthPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-month', { pattern: '[0-9]*', min: 1, max: 12, maxlength: 2, hintId: key + '-hint', date: true, autocomplete: autocomplete.month }));
-                yearPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-year', { pattern: '[0-9]*', maxlength: 4, hintId: key + '-hint', date: true, autocomplete: autocomplete.year }));
-                parts = parts.concat(monthPart, yearPart);
-
-                return parts.join('\n');
-            };
+            }
         };
 
-        res.locals['input-text-compound'] = function () {
-            return function (key) {
-                var obj = { compound: true };
-                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, obj));
-            };
-        };
-
-        res.locals['input-text-code'] = function () {
-            return function (key) {
-                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, { className: 'input-code' }));
-            };
-        };
-
-        res.locals['input-number'] = function () {
-            return function (key) {
-                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, { pattern: '[0-9]*' }));
-            };
-        };
-
-        res.locals['input-phone'] = function () {
-            return function (key) {
-                return compiled['partials/forms/input-text-group'].render(inputText.call(this, key, { maxlength: 18 }));
-            };
-        };
-
-        res.locals.textarea = function () {
-            return function (key) {
-                return compiled['partials/forms/textarea-group'].render(inputText.call(this, key));
-            };
-        };
-
-        res.locals['radio-group'] = function () {
-            return function (key) {
-                return compiled['partials/forms/radio-group'].render(optionGroup.call(this, key));
-            };
-        };
-
-        res.locals.select = function () {
-            return function (key) {
-                return compiled['partials/forms/select'].render(inputText.call(this, key, optionGroup.call(this, key)));
-            };
-        };
-
-        res.locals.checkbox = function () {
-            return function (key) {
-                return compiled['partials/forms/checkbox'].render(checkbox.call(this, key));
-            };
-        };
-
-        res.locals['checkbox-compound'] = function () {
-            var opts = { compound: true };
-            return function (key) {
-                return compiled['partials/forms/checkbox'].render(checkbox.call(this, key, opts));
-            };
-        };
-
-        res.locals['checkbox-required'] = function () {
-            var opts = { required: true };
-            return function (key) {
-                return compiled['partials/forms/checkbox'].render(checkbox.call(this, key, opts));
-            };
-        };
-
-        /**
-        * props: '[value] [id]'
-        */
-        res.locals['input-submit'] = function () {
-            return function (props) {
-                props = (props || '').split(' ');
-                var def = 'next',
-                    value = props[0] || def,
-                    id = props[1];
-
-                var obj = {
-                    value: t('buttons.' + value),
-                    id: id
+        // loop through mixins object and attach their handler methods
+        // to res.locals['mixin-name'].
+        _.each(mixins, function (mixin, name) {
+            var handler = _.isFunction(mixin.handler) ? mixin.handler : function () {
+                return function (key) {
+                    key = extractKey.call(this, key);
+                    return compiled[mixin.path]
+                        .render(mixin.renderWith.call(this, key, _.isFunction(mixin.options)
+                            ? mixin.options.call(this, key)
+                            : mixin.options
+                        ));
                 };
-                return compiled['partials/forms/input-submit'].render(obj);
             };
-        };
+            res.locals[name] = handler;
+        });
 
         res.locals.currency = function () {
             return function (txt) {

--- a/partials/forms/radio-group.html
+++ b/partials/forms/radio-group.html
@@ -19,5 +19,6 @@
             >
             {{{label}}}
         </label>
+        {{#renderChild}}{{/renderChild}}
     {{/options}}
 </fieldset>

--- a/partials/mixins/panel.html
+++ b/partials/mixins/panel.html
@@ -1,0 +1,5 @@
+<div id="{{toggle}}-panel" class="reveal js-hidden">
+    <div class="panel-indent">
+        {{#renderMixin}}{{/renderMixin}}
+    </div>
+</div>


### PR DESCRIPTION
* Added {{#renderChild}} call to radio-group mixin, called for each child
* Opt in functionality - pass displayToggleAsChild: true in radio group to enable
* The child field can be specified by passing childTemplate: 'textarea' or any other mixin name to render this as a child of the radio.