### PR TITLE
Add autocomplete to input fields and default to no attribute.

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -118,6 +118,13 @@ module.exports = function (fields, options) {
 
             extension = extension || {};
 
+            var autocomplete;
+            if (fields[key] && typeof fields[key].autocomplete === 'string') {
+                autocomplete = fields[key].autocomplete;
+            } else if (typeof extension.autocomplete === 'string' && extension.autocomplete) {
+                autocomplete = extension.autocomplete;
+            }
+
             return _.extend(extension, {
                 id: key,
                 className: extension.className || classNames(key),
@@ -132,6 +139,7 @@ module.exports = function (fields, options) {
                 required: required,
                 pattern: extension.pattern,
                 date: extension.date,
+                autocomplete: autocomplete,
                 attributes: fields[key] && fields[key].attributes
             });
         }
@@ -211,16 +219,31 @@ module.exports = function (fields, options) {
                 // Exact unless there is a inexact property against the fields key.
                 var isExact = fields[key] ? fields[key].inexact !== true : true;
 
+                var autocomplete = fields[key] && fields[key].autocomplete || {};
+                if (autocomplete === 'off') {
+                    autocomplete = {
+                        day: 'off',
+                        month: 'off',
+                        year: 'off'
+                    };
+                } else if (typeof autocomplete === 'string') {
+                    autocomplete = {
+                        day: autocomplete + '-day',
+                        month: autocomplete + '-month',
+                        year: autocomplete + '-year'
+                    };
+                }
+
                 var parts = [],
                     dayPart, monthPart, yearPart;
 
                 if (isExact) {
-                    dayPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-day', { pattern: '[0-9]*', min: 1, max: 31, maxlength: 2, hintId: key + '-hint', date: true }));
+                    dayPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-day', { pattern: '[0-9]*', min: 1, max: 31, maxlength: 2, hintId: key + '-hint', date: true, autocomplete: autocomplete.day }));
                     parts.push(dayPart);
                 }
 
-                monthPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-month', { pattern: '[0-9]*', min: 1, max: 12, maxlength: 2, hintId: key + '-hint', date: true }));
-                yearPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-year', { pattern: '[0-9]*', maxlength: 4, hintId: key + '-hint', date: true }));
+                monthPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-month', { pattern: '[0-9]*', min: 1, max: 12, maxlength: 2, hintId: key + '-hint', date: true, autocomplete: autocomplete.month }));
+                yearPart = compiled['partials/forms/input-text-group'].render(inputText.call(this, key + '-year', { pattern: '[0-9]*', maxlength: 4, hintId: key + '-hint', date: true, autocomplete: autocomplete.year }));
                 parts = parts.concat(monthPart, yearPart);
 
                 return parts.join('\n');

--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -18,6 +18,7 @@
         {{#pattern}} pattern="{{pattern}}"{{/pattern}}
         {{#hintId}} aria-describedby="{{hintId}}"{{/hintId}}
         {{#error}} aria-invalid="true"{{/error}}
+        {{#autocomplete}} autocomplete="{{autocomplete}}"{{/autocomplete}}
         {{#attributes}}
             {{attribute}}="{{value}}"
         {{/attributes}}

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -99,6 +99,31 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('should have an autocomplete setting if specified', function () {
+                middleware = mixins({
+                    'field-name': {
+                        'autocomplete': 'custom'
+                    }
+                });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    autocomplete: 'custom'
+                }));
+            });
+
+            it('should default to no autocomplete attribute ', function () {
+                middleware = mixins({
+                    'field-name': {
+                    }
+                });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    autocomplete: sinon.match.undefined
+                }));
+            });
+
             it('should have classes if one or more were specified against the field', function () {
                 middleware = mixins({
                     'field-name': {
@@ -357,6 +382,120 @@ describe('Template Mixins', function () {
                 yearCall.should.have.been.calledWith(sinon.match({
                     label: 'fields.field-name-year.label'
                 }));
+            });
+
+            describe('autocomplete', function () {
+
+                it('should have a sufix of -day -month and -year', function () {
+                    var autocompletemiddleware = mixins({
+                        'field-name': {
+                            'autocomplete': 'bday'
+                        }
+                    });
+                    autocompletemiddleware(req, res, next);
+                    res.locals['input-date']().call(res.locals, 'field-name');
+
+                    render.called;
+
+                    var dayCall = render.getCall(0),
+                        monthCall = render.getCall(1),
+                        yearCall = render.getCall(2);
+
+                    dayCall.should.have.been.calledWith(sinon.match({
+                        autocomplete: 'bday-day'
+                    }));
+
+                    monthCall.should.have.been.calledWith(sinon.match({
+                        autocomplete: 'bday-month'
+                    }));
+
+                    yearCall.should.have.been.calledWith(sinon.match({
+                        autocomplete: 'bday-year'
+                    }));
+                });
+
+                it('should be set as exact values if an object is given', function () {
+                    var autocompletemiddleware = mixins({
+                        'field-name': {
+                            'autocomplete': {
+                                day: 'day-type',
+                                month: 'month-type',
+                                year: 'year-type'
+                            }
+                        }
+                    });
+                    autocompletemiddleware(req, res, next);
+                    res.locals['input-date']().call(res.locals, 'field-name');
+
+                    render.called;
+
+                    var dayCall = render.getCall(0),
+                        monthCall = render.getCall(1),
+                        yearCall = render.getCall(2);
+
+                    dayCall.should.have.been.calledWith(sinon.match({
+                        autocomplete: 'day-type'
+                    }));
+
+                    monthCall.should.have.been.calledWith(sinon.match({
+                        autocomplete: 'month-type'
+                    }));
+
+                    yearCall.should.have.been.calledWith(sinon.match({
+                        autocomplete: 'year-type'
+                    }));
+                });
+
+                it('should set autocomplete to off if off is specified', function () {
+                    var autocompletemiddleware = mixins({
+                        'field-name': {
+                            'autocomplete': 'off'
+                        }
+                    });
+                    autocompletemiddleware(req, res, next);
+                    res.locals['input-date']().call(res.locals, 'field-name');
+
+                    render.called;
+
+                    var dayCall = render.getCall(0),
+                        monthCall = render.getCall(1),
+                        yearCall = render.getCall(2);
+
+                    dayCall.should.have.been.calledWith(sinon.match({
+                        autocomplete: 'off'
+                    }));
+
+                    monthCall.should.have.been.calledWith(sinon.match({
+                        autocomplete: 'off'
+                    }));
+
+                    yearCall.should.have.been.calledWith(sinon.match({
+                        autocomplete: 'off'
+                    }));
+                });
+
+                it('should default to no attribute across all date fields', function () {
+                    middleware(req, res, next);
+                    res.locals['input-date']().call(res.locals, 'field-name');
+
+                    render.called;
+
+                    var dayCall = render.getCall(0),
+                        monthCall = render.getCall(1),
+                        yearCall = render.getCall(2);
+
+                    dayCall.should.have.been.calledWith(sinon.match({
+                        autocomplete: undefined
+                    }));
+
+                    monthCall.should.have.been.calledWith(sinon.match({
+                        autocomplete: undefined
+                    }));
+
+                    yearCall.should.have.been.calledWith(sinon.match({
+                        autocomplete: undefined
+                    }));
+                });
             });
 
             it('prefixes translation lookup with namespace if provided', function () {


### PR DESCRIPTION
Chrome is currently ignoring autocomplete attributes on forms and inputs if they are set to 'off':
https://bugs.chromium.org/p/chromium/issues/detail?id=468153#c164
This is causing credit card information to be auto-completed into other fields, such as date-of-birth or expiry dates. Google suggests adding legitimate autocomplete values to input fields to avoid this:
https://html.spec.whatwg.org/multipage/forms.html#autofill

Date fields will suffix -day -month and -year, unless explicitly set in an object.
```
'name': {
   autocomplete: 'firstname'
},
'dob': {
  autocomplete: 'bday'
},
'mydate': {
  autocomplete: {
    day: 'bday-day',
    month: 'bday-month',
    year: 'customyear'
  }
},
'secretfield': {
  autocomplete: 'off' // explicitly off, ignored by chrome
},
'automatic': {
  // defaults to the autocomplete attribute not being present
}
```
