### PR TITLE
Feature - Support nested conditionals when looking up translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,36 @@ input-submit
 textarea
 ```
 
+## Conditional translations
+
+Locales files support nested conditional translations in order to show different content in different scenarios. This is supported in the `{{#t}}` mixin, and labels, hints and legends used in field config.
+
+```json
+"fields": {
+    "field-name": {
+        "label": {
+            "dependent-field": {
+                "value-1": {
+                    "dependent-field-2": {
+                        "value-1": "Label 1",
+                        "value-2": "Label 2"
+                    }
+                },
+                "value-2": "Label 3"
+            },
+            "default": "Fallback label"
+        }
+    }
+}
+```
+
+Using the translation key `fields.field-name.label` will return different values in different situations depending on the values of named fields. In the above example the following are true:
+
+* If both `dependent-field` and `dependent-field-2` have the value `"value-1"`, the label returned will be `"Label 1"`.
+* If the value of `dependent-field` is `"value-1"` and the value of `dependent-field-2` is `"value-2"`, the label returned will be `"Label 2"`.
+* If the value of `dependent-field` is `"value-2"` the label returned will be `"Label 3"` regardless of the value of `dependent-field-2`
+* The default label `"Fallback label"` will be used if value of `dependent-field` is neither of the given options, or it is `undefined`. It will also be used if the value of `dependent-field` is `"value-1"` and the value of `dependent-field-2` is neither of the given options or it is undefined.
+
 ## Options
 
 - `className`: A string or array of string class names.

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -82,8 +82,23 @@ module.exports = function (fields, options) {
 
         var translate = options.translate || req.translate || _.identity;
 
-        var t = function (key) {
-            return translate(sharedTranslationsKey + key);
+        var t = function (key, prependSharedKey) {
+            if (prependSharedKey !== false) {
+                key = sharedTranslationsKey + key;
+            }
+            var translated = translate(key);
+            if (_.isObject(translated)) {
+                translated = _.reduceRight(translated, function (prev, item, tKey) {
+                    var path = key + '.' + tKey;
+                    var result;
+                    if (_.isObject(item)) {
+                        path += '.' + req.form.values[tKey];
+                    }
+                    result = t(path, false);
+                    return result !== path ? result : prev;
+                }, '');
+            }
+            return translated;
         };
 
         // Like t() but returns null on failed translations
@@ -478,7 +493,7 @@ module.exports = function (fields, options) {
         res.locals.t = function () {
             return function (txt) {
                 txt = Hogan.compile(txt).render(this);
-                return t.apply(req, [txt, this]);
+                return t.call(req, txt);
             };
         };
 


### PR DESCRIPTION
* Expanded the t() function to recursively lookup keys/values from `req.form.values` if the result of a translation returns an object
* This is necessary to show different labels/hints etc depending on the value of other fields.

This feature is used by nesting any number of conditionals in the locales file.

```json
"fields": {
    "field-name": {
        "label": {
            "dependent-field": {
                "value-1": {
                    "dependent-field-2": {
                        "value-1": "Label 1",
                        "value-2": "Label 2"
                    }
                },
                "value-2": "Label 3"
            },
            "default": "Fallback label"
        }
    }
}
```