### PR TITLE
Moved aria-required tags from radio input element to fieldset contain…

### DIFF
--- a/partials/forms/radio-group.html
+++ b/partials/forms/radio-group.html
@@ -1,4 +1,4 @@
-<fieldset id="{{key}}-group" class="{{#className}}{{className}}{{/className}} {{#error}}validation-error{{/error}}">
+<fieldset id="{{key}}-group" class="{{#className}}{{className}}{{/className}} {{#error}}validation-error{{/error}}" role="radiogroup" aria-required="true">
     <legend>
         {{#error}}<span id="{{key}}-error" class="error-message">{{error.message}}</span>{{/error}}
         <span{{#legendClassName}} class="{{legendClassName}}"{{/legendClassName}}>{{legend}}</span>
@@ -11,7 +11,7 @@
                 name="{{key}}"
                 id="{{key}}-{{value}}"
                 value="{{value}}"
-                aria-required="true"
+                required="true"
                 {{#toggle}} data-toggle="{{toggle}}"{{/toggle}}
                 {{#selected}} checked="checked"{{/selected}}
                 {{^error}}{{#hint}} aria-describedby="{{key}}-hint"{{/hint}}{{/error}}


### PR DESCRIPTION
…er element

We've run Google Chrome's accessibility tool and it's flagged a severe issue where it tells us `aria-required="true"` isn't a valid tag to go on each radio input element. Instead it should be added to the element containing all of the radio inputs. This is the error reference flagged by the accessibility tool: https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_10

This StackOverflow post answers the same issue too: http://stackoverflow.com/a/34322810