### PR TITLE
load res.locals into context when compiling in lambdas

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -86,6 +86,12 @@ module.exports = function (fields, options) {
             return translate(sharedTranslationsKey + key);
         };
 
+        var hoganRender = function (text, ctx) {
+            if (!text) { return ''; }
+            ctx = _.extend({}, res.locals, ctx);
+            return Hogan.compile(text).render(ctx);
+        };
+
         // Like t() but returns null on failed translations
         var conditionalTranslate = function (key) {
             key = sharedTranslationsKey + key;
@@ -409,7 +415,8 @@ module.exports = function (fields, options) {
 
         res.locals.currency = function () {
             return function (txt) {
-                var value = parseFloat(Hogan.compile(txt).render(this));
+                txt = hoganRender(txt, this);
+                var value = parseFloat(txt);
                 if (isNaN(value)) {
                     return txt;
                 } else if (value % 1 === 0) {
@@ -424,30 +431,27 @@ module.exports = function (fields, options) {
         res.locals.date = function () {
             return function (txt) {
                 txt = (txt || '').split('|');
-                var value = Hogan.compile(txt[0]).render(this);
+                var value = hoganRender(txt[0], this);
                 return moment(value).format(txt[1] || 'D MMMM YYYY');
             };
         };
 
         res.locals.hyphenate = function () {
             return function (txt) {
-                txt = txt || '';
-                var value = Hogan.compile(txt).render(this);
+                var value = hoganRender(txt, this);
                 return value.trim().toLowerCase().replace(/\s+/g, '-');
             };
         };
 
         res.locals.uppercase = function () {
             return function (txt) {
-                txt = txt || '';
-                return Hogan.compile(txt).render(this).toUpperCase();
+                return hoganRender(txt, this).toUpperCase();
             };
         };
 
         res.locals.lowercase = function () {
             return function (txt) {
-                txt = txt || '';
-                return Hogan.compile(txt).render(this).toLowerCase();
+                return hoganRender(txt, this).toLowerCase();
             };
         };
 
@@ -467,24 +471,23 @@ module.exports = function (fields, options) {
         */
         res.locals.time = function () {
             return function (txt) {
-                txt = txt || '';
-                txt = Hogan.compile(txt).render(this);
+                txt = hoganRender(txt, this);
                 txt = txt.replace(/12:00am/i, 'midnight').replace(/^midnight/, 'Midnight');
-                txt = txt.replace(/12:00pm/i, 'midday').replace(/^middday/, 'Midday');
+                txt = txt.replace(/12:00pm/i, 'midday').replace(/^midday/, 'Midday');
                 return txt;
             };
         };
 
         res.locals.t = function () {
             return function (txt) {
-                txt = Hogan.compile(txt).render(this);
+                txt = hoganRender(txt, this);
                 return t.apply(req, [txt, this]);
             };
         };
 
         res.locals.url = function () {
             return function (url) {
-                url = Hogan.compile(url).render(this);
+                url = hoganRender(url, this);
                 return req.baseUrl ? path.resolve(req.baseUrl, url) : url;
             };
         };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run lint && npm run unit && npm run cover && npm run snyk",
     "lint": "eslint .",
     "unit": "mocha test/ --require ./test/helpers --recursive",
-    "cover": "istanbul cover _mocha -- test/ --recursive --require test/helpers",
+    "cover": "istanbul cover _mocha -- -R dot test/ --recursive --require test/helpers",
     "check-coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100 --line 100",
     "snyk": "snyk test"
   },

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -1076,6 +1076,153 @@ describe('Template Mixins', function () {
 
         });
 
+        describe('time', function () {
+
+            beforeEach(function () {
+                middleware = mixins();
+            });
+
+            it('adds a function to res.locals', function () {
+                middleware(req, res, next);
+                res.locals['time'].should.be.a('function');
+            });
+
+            it('returns a function', function () {
+                middleware(req, res, next);
+                res.locals['time']().should.be.a('function');
+            });
+
+            it('changes 12:00am to midnight', function () {
+                middleware(req, res, next);
+                res.locals['time']().call(res.locals, '26 March 2015 12:00am').should.equal('26 March 2015 midnight');
+            });
+
+            it('changes 12:00pm to midday', function () {
+                middleware(req, res, next);
+                res.locals['time']().call(res.locals, '26 March 2015 12:00pm').should.equal('26 March 2015 midday');
+            });
+
+            it('changes leading 12:00am to Midnight', function () {
+                middleware(req, res, next);
+                res.locals['time']().call(res.locals, '12:00am 26 March 2015').should.equal('Midnight 26 March 2015');
+            });
+
+            it('changes leading 12:00pm to Midday', function () {
+                middleware(req, res, next);
+                res.locals['time']().call(res.locals, '12:00pm 26 March 2015').should.equal('Midday 26 March 2015');
+            });
+
+            it('should pass through other times', function () {
+                middleware(req, res, next);
+                res.locals['time']().call(res.locals, '6:30am 26 March 2015').should.equal('6:30am 26 March 2015');
+            });
+        });
+
+        describe('uppercase', function () {
+            beforeEach(function () {
+                middleware = mixins();
+            });
+
+            it('adds a function to res.locals', function () {
+                middleware(req, res, next);
+                res.locals['uppercase'].should.be.a('function');
+            });
+
+            it('returns a function', function () {
+                middleware(req, res, next);
+                res.locals['uppercase']().should.be.a('function');
+            });
+
+            it('changes text to uppercase', function () {
+                middleware(req, res, next);
+                res.locals['uppercase']().call(res.locals, 'abcdEFG').should.equal('ABCDEFG');
+            });
+
+            it('returns an empty string if no text given', function () {
+                middleware(req, res, next);
+                res.locals['uppercase']().call(res.locals).should.equal('');
+            });
+        });
+
+        describe('lowercase', function () {
+            beforeEach(function () {
+                middleware = mixins();
+            });
+
+            it('adds a function to res.locals', function () {
+                middleware(req, res, next);
+                res.locals['lowercase'].should.be.a('function');
+            });
+
+            it('returns a function', function () {
+                middleware(req, res, next);
+                res.locals['lowercase']().should.be.a('function');
+            });
+
+            it('changes text to lowercase', function () {
+                middleware(req, res, next);
+                res.locals['lowercase']().call(res.locals, 'abcdEFG').should.equal('abcdefg');
+            });
+
+            it('returns an empty string if no text given', function () {
+                middleware(req, res, next);
+                res.locals['lowercase']().call(res.locals).should.equal('');
+            });
+        });
+
+        describe('currency', function () {
+            beforeEach(function () {
+                middleware = mixins();
+            });
+
+            it('adds a function to res.locals', function () {
+                middleware(req, res, next);
+                res.locals['currency'].should.be.a('function');
+            });
+
+            it('returns a function', function () {
+                middleware(req, res, next);
+                res.locals['currency']().should.be.a('function');
+            });
+
+            it('formats whole numbers with no decimal places', function () {
+                middleware(req, res, next);
+                res.locals['currency']().call(res.locals, '3.00').should.equal('£3');
+            });
+
+            it('formats 3.50 to two decimal places', function () {
+                middleware(req, res, next);
+                res.locals['currency']().call(res.locals, '3.50').should.equal('£3.50');
+            });
+
+            it('formats and rounds 3.567 to two decimal places', function () {
+                middleware(req, res, next);
+                res.locals['currency']().call(res.locals, '3.567').should.equal('£3.57');
+            });
+
+            it('formats 4.5678 to two decimal places from a local variable', function () {
+                middleware(req, res, next);
+                res.locals.value = 4.5678;
+                res.locals['currency']().call(res.locals, '{{value}}').should.equal('£4.57');
+            });
+
+            it('returns non float text as is', function () {
+                middleware(req, res, next);
+                res.locals['currency']().call(res.locals, 'test').should.equal('test');
+            });
+
+            it('returns non float template text as is', function () {
+                middleware(req, res, next);
+                res.locals.value = 'test';
+                res.locals['currency']().call(res.locals, '{{value}}').should.equal('test');
+            });
+
+            it('returns an empty string if no text given', function () {
+                middleware(req, res, next);
+                res.locals['currency']().call(res.locals).should.equal('');
+            });
+        });
+
         describe('hyphenate', function () {
 
             beforeEach(function () {
@@ -1190,6 +1337,21 @@ describe('Template Mixins', function () {
                     renderChild.call(scope).should.be.equal(customPartial);
                     fs.readFileSync.restore();
                 });
+            });
+
+        });
+
+        describe('Multiple lambdas', function () {
+            beforeEach(function () {
+                middleware = mixins();
+            });
+
+            it('recursively runs lambdas wrapped in other lambdas correctly', function () {
+                middleware(req, res, next);
+                res.locals.value = '2016-01-01T00:00:00.000Z';
+                var result = res.locals['uppercase']().call(res.locals,
+                    '{{#time}}{{#date}}{{value}}|h:mma on D MMMM YYYY{{/date}}{{/time}}');
+                result.should.equal('MIDNIGHT ON 1 JANUARY 2016');
             });
 
         });


### PR DESCRIPTION
load res.locals into context when compiling in lambdas so lambdas can be wrapped by other lambdas. eg:

{{#time}}
  {{#date}}
    {{timestamp}}|format
  {{/date}}
{{/time}}
