### PR TITLE
Move the error message below the label and hint

### DIFF
--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -1,9 +1,8 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{^date}}{{#error}} validation-error{{/error}}{{/date}}">
     <label for="{{id}}" class="{{labelClassName}}">
-        {{^date}}{{#error}}<span class="error-message" aria-hidden="true">{{error.message}}</span>{{/error}}{{/date}}
         {{{label}}}
         {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="form-hint">{{hint}}</span>{{/hint}}
-        {{^date}}{{#error}}<span class="visuallyhidden">{{error.message}}</span>{{/error}}{{/date}}
+        {{^date}}{{#error}}<span class="error-message">{{error.message}}</span>{{/error}}{{/date}}
     </label>
     <input
         type="{{type}}"

--- a/partials/forms/radio-group.html
+++ b/partials/forms/radio-group.html
@@ -1,8 +1,8 @@
 <fieldset id="{{key}}-group" class="{{#className}}{{className}}{{/className}} {{#error}}validation-error{{/error}}" role="radiogroup" aria-required="true">
     <legend>
-        {{#error}}<span id="{{key}}-error" class="error-message">{{error.message}}</span>{{/error}}
         <span{{#legendClassName}} class="{{legendClassName}}"{{/legendClassName}}>{{legend}}</span>
         {{#hint}}<span id="{{key}}-hint" class="form-hint">{{hint}}</span>{{/hint}}
+        {{#error}}<span id="{{key}}-error" class="error-message">{{error.message}}</span>{{/error}}
     </legend>
     {{#options}}
         <label class="block-label" for="{{key}}-{{value}}">

--- a/partials/forms/select.html
+++ b/partials/forms/select.html
@@ -1,9 +1,8 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
     <label for="{{id}}" class="{{labelClassName}}">
-        {{#error}}<span class="error-message" aria-hidden="true">{{error.message}}</span>{{/error}}
         {{{label}}}
         {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="form-hint">{{hint}}</span>{{/hint}}
-        {{#error}}<span class="visuallyhidden">{{error.message}}</span>{{/error}}
+        {{#error}}<span class="error-message">{{error.message}}</span>{{/error}}
     </label>
     <select id="{{id}}" class="{{#className}}{{className}}{{/className}}{{#error}} invalid-input{{/error}}" name="{{id}}" aria-required="{{required}}">
     {{#options}}


### PR DESCRIPTION
GOV.UK elements suggests that the error message for a field should be below the label and the hint, see http://govuk-elements.herokuapp.com/errors/. 

Currently `passports-templates-mixins` puts the error message for the `radio-group` mixin above the legend and this PR moves it to the correct position.

