### PR TITLE
Add child template to checkbox template mixin

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -191,6 +191,24 @@ module.exports = function (fields, options) {
             });
         }
 
+        function renderChild() {
+            return function () {
+                if (this.child) {
+                    var templateString = getTemplate(this.child, this.toggle);
+                    var template = Hogan.compile(templateString);
+                    return template.render(_.extend({
+                        renderMixin: function () {
+                            return function () {
+                                if (this.child && this[this.child]) {
+                                    return this[this.child]().call(this, this.toggle);
+                                }
+                            };
+                        }
+                    }, res.locals, this));
+                }
+            };
+        }
+
         function optionGroup(key) {
             var legend = fields[key] && fields[key].legend;
             var legendClassName;
@@ -235,23 +253,7 @@ module.exports = function (fields, options) {
                     };
                 }, this),
                 className: classNames(key),
-                renderChild: function () {
-                    return function () {
-                        if (this.child) {
-                            var templateString = getTemplate(this.child, this.toggle);
-                            var template = Hogan.compile(templateString);
-                            return template.render(_.extend({
-                                renderMixin: function () {
-                                    return function () {
-                                        if (this.child && this[this.child]) {
-                                            return this[this.child]().call(this, this.toggle);
-                                        }
-                                    };
-                                }
-                            }, res.locals, this));
-                        }
-                    };
-                }
+                renderChild: renderChild.bind(this)
             };
         }
 
@@ -270,7 +272,9 @@ module.exports = function (fields, options) {
                 invalid: this.errors && this.errors[key] && opts.required,
                 label: t(fieldLabel || 'fields.' + key + '.label'),
                 selected: selected,
-                className: classNames(key) || 'block-label'
+                className: classNames(key) || 'block-label',
+                child: fields[key] && fields[key].child,
+                renderChild: renderChild.bind(this)
             });
         }
 

--- a/partials/forms/checkbox.html
+++ b/partials/forms/checkbox.html
@@ -5,4 +5,5 @@
         {{{label}}}
         {{#error}}<span class="visuallyhidden">{{error.message}}</span>{{/error}}
     </label>
+    {{#renderChild}}{{/renderChild}}
 </div>


### PR DESCRIPTION
* Reuse the functionality from the radio group renderChild method to allow templates to be rendered as a child of checkboxes
* Move the unit tests for child templates out of the 'without stubbed Hogan' section as they use a mixture of stubbed Hogan and Hogan
* Add more explicit field config to the tests as a means of documentation