### PR TITLE
Update textarea error and hint markup

### DIFF
--- a/partials/forms/textarea-group.html
+++ b/partials/forms/textarea-group.html
@@ -1,9 +1,8 @@
 <div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
     <label for="{{id}}" class="{{labelClassName}}">
-        {{#error}}<span class="error-message" aria-hidden="true">{{error.message}}</span>{{/error}}
         {{{label}}}
         {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="form-hint">{{hint}}</span>{{/hint}}
-        {{#error}}<span class="visuallyhidden">{{error.message}}</span>{{/error}}
+        {{#error}}<span id="{{id}}-error" class="error-message">{{error.message}}</span>{{/error}}
     </label>
     <textarea
         name="{{id}}"
@@ -14,7 +13,7 @@
         {{#attributes}}
             {{attribute}}="{{value}}"
         {{/attributes}}
-        {{#hintId}} aria-describedby="{{hintId}}"{{/hintId}}
-        {{#error}} aria-invalid="true"{{/error}}
+        {{^error}}{{#hintId}} aria-describedby="{{hintId}}"{{/hintId}}{{/error}}
+        {{#error}} aria-invalid="true" aria-describedby="{{id}}-error"{{/error}}
     >{{value}}</textarea>
 </div>


### PR DESCRIPTION
Update the error layout of textareas to match other form inputs. Set `aria-describedby` to error when there's an error, otherwise use the hint when this exists.