### PR TITLE
Update mixins to use new styles

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -269,7 +269,6 @@ module.exports = function (fields, options) {
             return _.extend(opts, {
                 key: key,
                 error: this.errors && this.errors[key],
-                invalid: this.errors && this.errors[key] && opts.required,
                 label: t(fieldLabel || 'fields.' + key + '.label'),
                 selected: selected,
                 className: classNames(key) || 'block-label',

--- a/partials/forms/checkbox.html
+++ b/partials/forms/checkbox.html
@@ -1,9 +1,9 @@
-<div id="{{key}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
+<div id="{{key}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} error{{/error}}">
     {{#error}}<p class="error-message" aria-hidden="true">{{error.message}}</p>{{/error}}
-    <label for="{{key}}" class="{{#className}}{{className}} {{/className}}{{#invalid}}invalid-input{{/invalid}}">
+    <label for="{{key}}"{{#className}} class="{{className}}"{{/className}}>
         <input type="checkbox" id="{{key}}" name="{{key}}" value="true" aria-required="{{required}}"{{#error}} aria-invalid="true"{{/error}}{{^error}}{{#toggle}} data-toggle="{{toggle}}"{{/toggle}}{{#selected}} checked="checked"{{/selected}}{{/error}}>
         {{{label}}}
-        {{#error}}<span class="visuallyhidden">{{error.message}}</span>{{/error}}
+        {{#error}}<span class="visually-hidden">{{error.message}}</span>{{/error}}
     </label>
     {{#renderChild}}{{/renderChild}}
 </div>

--- a/partials/forms/input-submit.html
+++ b/partials/forms/input-submit.html
@@ -1,1 +1,3 @@
-<input type="submit" {{#id}}id="{{id}}"{{/id}} value="{{{value}}}" class="button">
+<div class="form-group">
+    <input type="submit" {{#id}}id="{{id}}"{{/id}} value="{{{value}}}" class="button">
+</div>

--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -8,7 +8,7 @@
         type="{{type}}"
         name="{{id}}"
         id="{{id}}"
-        class="form-control{{#className}} {{className}}{{/className}}"
+        class="form-control{{#className}} {{className}}{{/className}}{{#date}}{{#error}} invalid-input{{/error}}{{/date}}"
         aria-required="{{required}}"
         {{#value}} value="{{value}}"{{/value}}
         {{#min}} min="{{min}}"{{/min}}

--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -1,4 +1,4 @@
-<div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{^date}}{{#error}} validation-error{{/error}}{{/date}}">
+<div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{^date}}{{#error}} error{{/error}}{{/date}}">
     <label for="{{id}}" class="{{labelClassName}}">
         {{{label}}}
         {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="form-hint">{{hint}}</span>{{/hint}}
@@ -8,7 +8,7 @@
         type="{{type}}"
         name="{{id}}"
         id="{{id}}"
-        class="form-control{{#className}} {{className}}{{/className}}{{#error}} invalid-input{{/error}}"
+        class="form-control{{#className}} {{className}}{{/className}}"
         aria-required="{{required}}"
         {{#value}} value="{{value}}"{{/value}}
         {{#min}} min="{{min}}"{{/min}}

--- a/partials/forms/radio-group.html
+++ b/partials/forms/radio-group.html
@@ -1,4 +1,4 @@
-<fieldset id="{{key}}-group" class="{{#className}}{{className}}{{/className}} {{#error}}validation-error{{/error}}" role="radiogroup" aria-required="true">
+<fieldset id="{{key}}-group" class="{{#className}}{{className}}{{/className}} {{#error}}error{{/error}}" role="radiogroup" aria-required="true">
     <legend>
         <span{{#legendClassName}} class="{{legendClassName}}"{{/legendClassName}}>{{legend}}</span>
         {{#hint}}<span id="{{key}}-hint" class="form-hint">{{hint}}</span>{{/hint}}

--- a/partials/forms/radio-group.html
+++ b/partials/forms/radio-group.html
@@ -1,24 +1,26 @@
-<fieldset id="{{key}}-group" class="{{#className}}{{className}}{{/className}} {{#error}}error{{/error}}" role="radiogroup" aria-required="true">
-    <legend>
-        <span{{#legendClassName}} class="{{legendClassName}}"{{/legendClassName}}>{{legend}}</span>
-        {{#hint}}<span id="{{key}}-hint" class="form-hint">{{hint}}</span>{{/hint}}
-        {{#error}}<span id="{{key}}-error" class="error-message">{{error.message}}</span>{{/error}}
-    </legend>
-    {{#options}}
-        <label class="block-label" for="{{key}}-{{value}}">
-            <input
-                type="radio"
-                name="{{key}}"
-                id="{{key}}-{{value}}"
-                value="{{value}}"
-                required="true"
-                {{#toggle}} data-toggle="{{toggle}}"{{/toggle}}
-                {{#selected}} checked="checked"{{/selected}}
-                {{^error}}{{#hint}} aria-describedby="{{key}}-hint"{{/hint}}{{/error}}
-                {{#error}} aria-describedby="{{key}}-error" aria-invalid="true"{{/error}}
-            >
-            {{{label}}}
-        </label>
-        {{#renderChild}}{{/renderChild}}
-    {{/options}}
-</fieldset>
+<div id="{{key}}-group" class="form-group{{#className}} {{className}} {{/className}}{{#error}} error{{/error}}">
+    <fieldset role="radiogroup" aria-required="true">
+        <legend>
+            <span{{#legendClassName}} class="{{legendClassName}}"{{/legendClassName}}>{{legend}}</span>
+            {{#hint}}<span id="{{key}}-hint" class="form-hint">{{hint}}</span>{{/hint}}
+            {{#error}}<span id="{{key}}-error" class="error-message">{{error.message}}</span>{{/error}}
+        </legend>
+        {{#options}}
+            <label class="block-label" for="{{key}}-{{value}}">
+                <input
+                    type="radio"
+                    name="{{key}}"
+                    id="{{key}}-{{value}}"
+                    value="{{value}}"
+                    required="true"
+                    {{#toggle}} data-toggle="{{toggle}}"{{/toggle}}
+                    {{#selected}} checked="checked"{{/selected}}
+                    {{^error}}{{#hint}} aria-describedby="{{key}}-hint"{{/hint}}{{/error}}
+                    {{#error}} aria-describedby="{{key}}-error" aria-invalid="true"{{/error}}
+                >
+                {{{label}}}
+            </label>
+            {{#renderChild}}{{/renderChild}}
+        {{/options}}
+    </fieldset>
+</div>

--- a/partials/forms/select.html
+++ b/partials/forms/select.html
@@ -1,10 +1,10 @@
-<div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} validation-error{{/error}}">
+<div id="{{id}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} error{{/error}}">
     <label for="{{id}}" class="{{labelClassName}}">
         {{{label}}}
         {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="form-hint">{{hint}}</span>{{/hint}}
         {{#error}}<span class="error-message">{{error.message}}</span>{{/error}}
     </label>
-    <select id="{{id}}" class="{{#className}}{{className}}{{/className}}{{#error}} invalid-input{{/error}}" name="{{id}}" aria-required="{{required}}">
+    <select id="{{id}}" class="{{#className}}{{className}}{{/className}}" name="{{id}}" aria-required="{{required}}">
     {{#options}}
         <option value="{{value}}" {{#selected}}selected{{/selected}}>{{label}}</option>
     {{/options}}

--- a/partials/mixins/panel.html
+++ b/partials/mixins/panel.html
@@ -1,5 +1,5 @@
 <div id="{{toggle}}-panel" class="reveal js-hidden">
-    <div class="panel-indent">
+    <div class="panel panel-border-narrow">
         {{#renderMixin}}{{/renderMixin}}
     </div>
 </div>

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -1376,7 +1376,7 @@ describe('Template Mixins', function () {
                         return Hogan.compile('<div>{{key}}</div>').render({ key: key });
                     });
                     var output = '<div id="child-field-name-panel" class="reveal js-hidden">';
-                    output += '\n    <div class="panel-indent">\n';
+                    output += '\n    <div class="panel panel-border-narrow">\n';
                     output += '<div>child-field-name</div>';
                     output += '    </div>';
                     output += '\n</div>\n';
@@ -1455,7 +1455,7 @@ describe('Template Mixins', function () {
                         return Hogan.compile('<div>{{key}}</div>').render({ key: key });
                     });
                     var output = '<div id="child-field-name-panel" class="reveal js-hidden">';
-                    output += '\n    <div class="panel-indent">\n';
+                    output += '\n    <div class="panel panel-border-narrow">\n';
                     output += '<div>child-field-name</div>';
                     output += '    </div>';
                     output += '\n</div>\n';


### PR DESCRIPTION
Update template mixins to use the new styles in hmpo-frontend-toolkit.

* `panel-indent` is now `panel panel-border-narrow`
* `validation-error` is now `error`
* Inputs with errors inherit styles from `.error`
* Move `form-group` class and ID from radio group fieldset and add to new wrapping div
* Wrap submit input in `form-group` class for consistent spacing
* prefer `visually-hidden` over `visuallyhidden`
