### PR TITLE
Remove visually hidden error message in checkbox mixin

### DIFF
--- a/partials/forms/checkbox.html
+++ b/partials/forms/checkbox.html
@@ -1,9 +1,8 @@
 <div id="{{key}}-group" class="form-group{{#compound}} form-group-compound{{/compound}}{{#error}} error{{/error}}">
-    {{#error}}<p class="error-message" aria-hidden="true">{{error.message}}</p>{{/error}}
+    {{#error}}<p id="{{key}}-error" class="error-message">{{error.message}}</p>{{/error}}
     <label for="{{key}}"{{#className}} class="{{className}}"{{/className}}>
-        <input type="checkbox" id="{{key}}" name="{{key}}" value="true" aria-required="{{required}}"{{#error}} aria-invalid="true"{{/error}}{{^error}}{{#toggle}} data-toggle="{{toggle}}"{{/toggle}}{{#selected}} checked="checked"{{/selected}}{{/error}}>
+        <input type="checkbox" id="{{key}}" name="{{key}}" value="true" aria-required="{{required}}"{{#error}} aria-invalid="true" aria-describedby="{{key}}-error"{{/error}}{{^error}}{{#toggle}} data-toggle="{{toggle}}"{{/toggle}}{{#selected}} checked="checked"{{/selected}}{{/error}}>
         {{{label}}}
-        {{#error}}<span class="visually-hidden">{{error.message}}</span>{{/error}}
     </label>
     {{#renderChild}}{{/renderChild}}
 </div>


### PR DESCRIPTION
Remove the visually hidden error message and `aria-hidden` attribute from the visible error message so there's only one error message in the checkbox mixin. Link the input to the error message (when there's an error) using `aria-describedby` for assistive tech users.

Fixes #69.