### PR TITLE
closes #74 - Radio group and checkbox group labels should be looked u…

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -234,10 +234,10 @@ module.exports = function (fields, options) {
 
                     if (typeof obj === 'string') {
                         value = obj;
-                        label = obj;
+                        label = 'fields.' + key + '.options.' + obj + '.label';
                     } else {
                         value = obj.value;
-                        label = obj.label;
+                        label = obj.label || 'fields.' + key + '.options.' + obj.value + '.label';
                         toggle = obj.toggle;
                         child = obj.child;
                     }

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -851,6 +851,34 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('looks up field label from fields.field-name.options.foo.label if not specified', function () {
+                middleware = mixins({
+                    'field-name': {
+                        options: ['foo', 'bar']
+                    }
+                });
+                middleware(req, res, next);
+                res.locals['radio-group']().call(res.locals, 'field-name');
+                render.args[0][0].options[0].label.should.be.equal('fields.field-name.options.foo.label');
+                render.args[0][0].options[1].label.should.be.equal('fields.field-name.options.bar.label');
+            });
+
+            it('looks up field label from fields.field-name.options.foo.label if not specified (object options)', function () {
+                middleware = mixins({
+                    'field-name': {
+                        options: [{
+                            value: 'foo'
+                        }, {
+                            value: 'bar'
+                        }]
+                    }
+                });
+                middleware(req, res, next);
+                res.locals['radio-group']().call(res.locals, 'field-name');
+                render.args[0][0].options[0].label.should.be.equal('fields.field-name.options.foo.label');
+                render.args[0][0].options[1].label.should.be.equal('fields.field-name.options.bar.label');
+            });
+
             it('should have classes if one or more were specified against the field', function () {
                 middleware = mixins({
                     'field-name': {


### PR DESCRIPTION
…p automatically

* if label not specified in option config, look up with `'fields.{field-name}.options.{option-value}.label'`
* applied the above for simple options array
* added tests