### PR TITLE
enhancement - allow string interpolation in translations strings.

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -82,14 +82,14 @@ module.exports = function (fields, options) {
 
         var translate = options.translate || req.translate || _.identity;
 
-        var t = function (key) {
-            return translate(sharedTranslationsKey + key);
-        };
-
         var hoganRender = function (text, ctx) {
             if (!text) { return ''; }
             ctx = _.extend({}, res.locals, ctx);
             return Hogan.compile(text).render(ctx);
+        };
+
+        var t = function (key) {
+            return hoganRender(translate(sharedTranslationsKey + key), this);
         };
 
         // Like t() but returns null on failed translations

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -33,8 +33,10 @@ describe('Template Mixins', function () {
 
         beforeEach(function () {
             render = sinon.stub();
-            sinon.stub(Hogan, 'compile').returns({
-                render: render
+            sinon.stub(Hogan, 'compile', function (text) {
+                return {
+                    render: render.returns(text)
+                };
             });
         });
 
@@ -345,13 +347,13 @@ describe('Template Mixins', function () {
                 res.locals['input-date']().should.be.a('function');
             });
 
-            it('renders thrice if the field is not marked as inexact', function () {
+            it('renders 6 times if the field is not marked as inexact', function () {
                 middleware(req, res, next);
                 res.locals['input-date']().call(res.locals, 'field-name');
-                render.should.have.been.calledThrice;
+                render.callCount.should.be.equal(6);
             });
 
-            it('renders twice if the field is marked as inexact', function () {
+            it('renders 4 times if the field is marked as inexact', function () {
                 var middlewareWithFieldNameMarkedAsInexact = mixins({
                     'field-name': {
                         'inexact': true
@@ -359,7 +361,7 @@ describe('Template Mixins', function () {
                 });
                 middlewareWithFieldNameMarkedAsInexact(req, res, next);
                 res.locals['input-date']().call(res.locals, 'field-name');
-                render.should.have.been.calledTwice;
+                render.callCount.should.be.equal(4);
             });
 
             it('looks up field label', function () {
@@ -368,9 +370,9 @@ describe('Template Mixins', function () {
 
                 render.called;
 
-                var dayCall = render.getCall(0),
-                    monthCall = render.getCall(1),
-                    yearCall = render.getCall(2);
+                var dayCall = render.getCall(1),
+                    monthCall = render.getCall(3),
+                    yearCall = render.getCall(5);
 
                 dayCall.should.have.been.calledWith(sinon.match({
                     label: 'fields.field-name-day.label'
@@ -398,9 +400,9 @@ describe('Template Mixins', function () {
 
                     render.called;
 
-                    var dayCall = render.getCall(0),
-                        monthCall = render.getCall(1),
-                        yearCall = render.getCall(2);
+                    var dayCall = render.getCall(1),
+                        monthCall = render.getCall(3),
+                        yearCall = render.getCall(5);
 
                     dayCall.should.have.been.calledWith(sinon.match({
                         autocomplete: 'bday-day'
@@ -430,9 +432,9 @@ describe('Template Mixins', function () {
 
                     render.called;
 
-                    var dayCall = render.getCall(0),
-                        monthCall = render.getCall(1),
-                        yearCall = render.getCall(2);
+                    var dayCall = render.getCall(1),
+                        monthCall = render.getCall(3),
+                        yearCall = render.getCall(5);
 
                     dayCall.should.have.been.calledWith(sinon.match({
                         autocomplete: 'day-type'
@@ -458,9 +460,9 @@ describe('Template Mixins', function () {
 
                     render.called;
 
-                    var dayCall = render.getCall(0),
-                        monthCall = render.getCall(1),
-                        yearCall = render.getCall(2);
+                    var dayCall = render.getCall(1),
+                        monthCall = render.getCall(3),
+                        yearCall = render.getCall(5);
 
                     dayCall.should.have.been.calledWith(sinon.match({
                         autocomplete: 'off'
@@ -506,9 +508,9 @@ describe('Template Mixins', function () {
 
                 render.called;
 
-                var dayCall = render.getCall(0),
-                    monthCall = render.getCall(1),
-                    yearCall = render.getCall(2);
+                var dayCall = render.getCall(1),
+                    monthCall = render.getCall(3),
+                    yearCall = render.getCall(5);
 
                 dayCall.should.have.been.calledWith(sinon.match({
                     label: 'name.space.fields.field-name-day.label'
@@ -527,13 +529,13 @@ describe('Template Mixins', function () {
                 middleware(req, res, next);
                 res.locals['input-date']().call(res.locals, 'field-name');
 
-                render.getCall(0).should.have.been.calledWithExactly(sinon.match({
-                    date: true
-                }));
                 render.getCall(1).should.have.been.calledWithExactly(sinon.match({
                     date: true
                 }));
-                render.getCall(2).should.have.been.calledWithExactly(sinon.match({
+                render.getCall(3).should.have.been.calledWithExactly(sinon.match({
+                    date: true
+                }));
+                render.getCall(5).should.have.been.calledWithExactly(sinon.match({
                     date: true
                 }));
             });
@@ -839,7 +841,7 @@ describe('Template Mixins', function () {
                 });
                 middleware(req, res, next);
                 res.locals['radio-group']().call(res.locals, 'field-name');
-                render.should.have.been.calledWith(sinon.match(function (value) {
+                render.thirdCall.should.have.been.calledWith(sinon.match(function (value) {
                     var obj = value.options[0];
                     return _.isMatch(obj, {
                         label: 'Foo',
@@ -859,8 +861,8 @@ describe('Template Mixins', function () {
                 });
                 middleware(req, res, next);
                 res.locals['radio-group']().call(res.locals, 'field-name');
-                render.args[0][0].options[0].label.should.be.equal('fields.field-name.options.foo.label');
-                render.args[0][0].options[1].label.should.be.equal('fields.field-name.options.bar.label');
+                render.args[3][0].options[0].label.should.be.equal('fields.field-name.options.foo.label');
+                render.args[3][0].options[1].label.should.be.equal('fields.field-name.options.bar.label');
             });
 
             it('looks up field label from fields.field-name.options.foo.label if not specified (object options)', function () {
@@ -875,8 +877,8 @@ describe('Template Mixins', function () {
                 });
                 middleware(req, res, next);
                 res.locals['radio-group']().call(res.locals, 'field-name');
-                render.args[0][0].options[0].label.should.be.equal('fields.field-name.options.foo.label');
-                render.args[0][0].options[1].label.should.be.equal('fields.field-name.options.bar.label');
+                render.args[3][0].options[0].label.should.be.equal('fields.field-name.options.foo.label');
+                render.args[3][0].options[1].label.should.be.equal('fields.field-name.options.bar.label');
             });
 
             it('should have classes if one or more were specified against the field', function () {
@@ -1138,7 +1140,7 @@ describe('Template Mixins', function () {
                     };
                     middleware(req, res, next);
                     res.locals['checkbox-group']().call(res.locals, 'field-name');
-                    var options = render.args[0][0].options;
+                    var options = render.args[4][0].options;
                     _.pluck(options.filter(function (option) {
                         return option.selected;
                     }), 'value').should.be.eql(['foo', 'bar']);
@@ -1150,7 +1152,7 @@ describe('Template Mixins', function () {
                     };
                     middleware(req, res, next);
                     res.locals['checkbox-group']().call(res.locals, 'field-name');
-                    var options = render.args[0][0].options;
+                    var options = render.args[4][0].options;
                     _.pluck(options.filter(function (option) {
                         return option.selected;
                     }), 'value').should.be.eql(['foo', 'bar', 'baz']);
@@ -1162,7 +1164,7 @@ describe('Template Mixins', function () {
                     };
                     middleware(req, res, next);
                     res.locals['checkbox-group']().call(res.locals, 'field-name');
-                    var options = render.args[0][0].options;
+                    var options = render.args[4][0].options;
                     _.pluck(options.filter(function (option) {
                         return option.selected;
                     }), 'value').should.be.eql(['foo', 'baz']);
@@ -1174,7 +1176,7 @@ describe('Template Mixins', function () {
                     };
                     middleware(req, res, next);
                     res.locals['checkbox-group']().call(res.locals, 'field-name');
-                    var options = render.args[0][0].options;
+                    var options = render.args[4][0].options;
                     _.pluck(options.filter(function (option) {
                         return option.selected;
                     }), 'value').should.be.eql(['bar']);


### PR DESCRIPTION
This addition allows translations strings to include variables present in res.locals when included as implicit translations such as labels and legends. This functionality already exists for {{#t}} mixin

```json
"fields": {
  "field-name": {
    "label": "Enter the {{variable}}"
  }
}
```

* amended t function to call hoganRender
* amended tests to point to the correct call of render stub