### PR TITLE
enhancement - expose partials to renderChild mixin

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -168,7 +168,9 @@ module.exports = function (fields, options) {
                 pattern: extension.pattern,
                 date: extension.date,
                 autocomplete: autocomplete,
-                attributes: fields[key] && fields[key].attributes
+                child: fields[key] && fields[key].child,
+                attributes: fields[key] && fields[key].attributes,
+                renderChild: renderChild.bind(this)
             });
         }
 
@@ -185,7 +187,9 @@ module.exports = function (fields, options) {
                                 }
                             };
                         }
-                    }, res.locals, this));
+                    }, res.locals, this), _.mapObject(res.locals.partials, function (path) {
+                        return Hogan.compile(fs.readFileSync(path + '.' + viewEngine).toString());
+                    }));
                 }
             };
         }

--- a/partials/forms/input-text-group.html
+++ b/partials/forms/input-text-group.html
@@ -4,6 +4,7 @@
         {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="form-hint">{{hint}}</span>{{/hint}}
         {{^date}}{{#error}}<span class="error-message">{{error.message}}</span>{{/error}}{{/date}}
     </label>
+    {{#renderChild}}{{/renderChild}}
     <input
         type="{{type}}"
         name="{{id}}"

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var mixins = require('../lib/template-mixins');
 var _ = require('underscore');
 var Hogan = require('hogan.js');
@@ -77,6 +78,19 @@ describe('Template Mixins', function () {
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
                     label: 'fields.field-name.label'
+                }));
+            });
+
+            it('passes child from field config', function () {
+                middleware = mixins({
+                    'field-name': {
+                        child: 'a child'
+                    }
+                });
+                middleware(req, res, next);
+                res.locals['input-text']().call(res.locals, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    child: 'a child'
                 }));
             });
 
@@ -1626,6 +1640,22 @@ describe('Template Mixins', function () {
                         key: 'value'
                     };
                     renderChild.call(fields['field-name'].options[0]).should.be.equal('<div>value</div>');
+                    sinon.stub(Hogan, 'compile').returns({
+                        render: render
+                    });
+                });
+
+                it('can lookup partial templates', function () {
+                    Hogan.compile.restore();
+                    var partialPath = path.resolve(__dirname, './test-partial.html').replace('.html', '');
+                    res.locals.partials = {
+                        'partials-test-partial': partialPath
+                    };
+                    options[0] = {
+                        child: '{{< partials-test-partial}}{{$title}}Title{{/title}}{{$content}}The content{{/content}}{{/partials-test-partial}}',
+                        key: 'value'
+                    };
+                    renderChild.call(fields['field-name'].options[0]).should.be.equal('<h1>Title</h1>\n<p>The content</p>\n');
                     sinon.stub(Hogan, 'compile').returns({
                         render: render
                     });

--- a/test/test-partial.html
+++ b/test/test-partial.html
@@ -1,0 +1,2 @@
+<h1>{{$title}}{{/title}}</h1>
+<p>{{$content}}{{/content}}</p>


### PR DESCRIPTION
partials need to be provided to the render function in renderChild in order for them to be rendered in the application.

In some applications we also have a requirement to add content between the label and the field (details/summary) - added renderChild functionality to input-text-group mixin

* expose res.locals.partials to render function
* added renderChild to input-text group