### PR TITLE
time format should shorten 4:00pm to 4pm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,16 @@ Static field configuration - Default: `{}`
 
 ```
 t
-time
 selected
 lowercase
 uppercase
+capscase
 hyphenate
 date
+time
 currency
+currencyOrFree
+url
 select
 input-text
 input-date
@@ -103,3 +106,38 @@ textarea
 - `toggle`: Can be used to toggle the display of the HTML element with a matching `id`. See [passports-frontend-toolkit](https://github.com/UKHomeOffice/passports-frontend-toolkit/blob/master/assets/javascript/progressive-reveal.js) for details.
 - `attributes`: A hash of key/value pairs applicable to a HTML `textarea` field. Each key/value is assigned as an attribute of the `textarea`. For example `spellcheck="true"`.
 - `child`: Render a child partial beneath each option in an `optionGroup`. Accepts a custom mustache template string, a custom partial in the format `partials/{your-partial-name}` or a template mixin key which will be rendered within a panel element partial.
+
+## `date` mixin
+
+Dates should be provided to the date lambda in ISO format
+```
+{{#date}}2017-06-03T12:34:56.000Z{/date}
+3 June 2017
+```
+
+A moment format can be supplied. The default format is D MMMM YYYY.
+```
+{{#date}}2017-06-3T12:34:56.000Z|DD MMM YYYY HH:MMa{/date}
+03 Jun 2017 12:34pm
+```
+
+## `time` mixin
+
+The time formatter wraps a formatted time to correct for GDS standard:
+```
+{{#time}}3:00pm{{/time}}
+3pm
+
+{{#time}}11 May 2017 at 12:00pm{{/time}}
+11 May 2017 at midday
+
+{{#time}}12:00am{{/time}}
+Midnight
+```
+
+Comma separated options can be provided to only do transforms for midday, midnight, or shortened time:
+```
+{{#time}}12:00pm|short,midnight{{/time}}
+12pm
+```
+

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -490,9 +490,10 @@ module.exports = function (options, deprecated) {
 
         res.locals.date = function () {
             return function (txt) {
-                txt = (txt || '').split('|');
-                var value = hoganRender(txt[0], this);
-                return moment(value).format(txt[1] || 'D MMMM YYYY');
+                txt = hoganRender(txt, this).split('|');
+                let value = txt[0];
+                let format = txt[1] || 'D MMMM YYYY';
+                return moment(value).format(format);
             };
         };
 
@@ -538,10 +539,22 @@ module.exports = function (options, deprecated) {
         */
         res.locals.time = function () {
             return function (txt) {
-                txt = hoganRender(txt, this);
-                txt = txt.replace(/12:00am/i, 'midnight').replace(/^midnight/, 'Midnight');
-                txt = txt.replace(/12:00pm/i, 'midday').replace(/^midday/, 'Midday');
-                return txt;
+                txt = hoganRender(txt, this).split('|');
+                let value = txt[0];
+                let options = txt[1] || 'short,midnight,midday';
+                options = _.indexBy(options.split(/\s*,\s*/));
+                if (options.midnight) {
+                    value = value.replace(/12:00am/ig, 'midnight');
+                    value = value.replace(/^midnight/, 'Midnight');
+                }
+                if (options.midday) {
+                    value = value.replace(/12:00pm/ig, 'midday');
+                    value = value.replace(/^midday/, 'Midday');
+                }
+                if (options.short) {
+                    value = value.replace(/:00(am|pm)/ig, '$1');
+                }
+                return value;
             };
         };
 

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -1760,6 +1760,18 @@ describe('Template Mixins', function () {
                 res.locals['time']().call(res.locals, '12:00pm 26 March 2015').should.equal('Midday 26 March 2015');
             });
 
+            it('changes 4:00pm to 4pm', function () {
+                res.locals['time']().call(res.locals, '26 March 2015 4:00pm').should.equal('26 March 2015 4pm');
+            });
+
+            it('changes 12:00pm to 12pm if options only specify short', function () {
+                res.locals['time']().call(res.locals, '26 March 2015 12:00pm|short').should.equal('26 March 2015 12pm');
+            });
+
+            it('changes 12:00am to 12am if options do not specify midnight', function () {
+                res.locals['time']().call(res.locals, '26 March 2015 12:00am|short,midday').should.equal('26 March 2015 12am');
+            });
+
             it('should pass through other times', function () {
                 res.locals['time']().call(res.locals, '6:30am 26 March 2015').should.equal('6:30am 26 March 2015');
             });


### PR DESCRIPTION
Time format should shorten 4:00pm to 4pm.
Add options to be able to only do midday, midnight or shortened
Hogan render inner before separating formats or options, or inner options get picked up by split

<img width="720" alt="screen_shot_2017-06-26_at_10 31 30" src="https://user-images.githubusercontent.com/128149/27541384-a71cd642-5a7b-11e7-878b-3d32820d0f15.png">

https://www.gov.uk/service-manual/design/dates
