### PR TITLE
Object assign this and res.locals to be used by mixins

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -514,12 +514,13 @@ module.exports = function (options, deprecated) {
         _.each(mixins, function (mixin, name) {
             var handler = _.isFunction(mixin.handler) ? mixin.handler : function () {
                 return function (key) {
-                    key = extractKey.call(this, key);
-                    this.options = this.options || {};
-                    this.options.fields = this.options.fields || {};
+                    let ctx = Object.assign({}, res.locals, this);
+                    key = extractKey.call(ctx, key);
+                    ctx.options = ctx.options || {};
+                    ctx.options.fields = ctx.options.fields || {};
                     return compiled[mixin.path]
-                        .render(mixin.renderWith.call(this, key, _.isFunction(mixin.options)
-                            ? mixin.options.call(this, key)
+                        .render(mixin.renderWith.call(ctx, key, _.isFunction(mixin.options)
+                            ? mixin.options.call(ctx, key)
                             : mixin.options
                         ));
                 };

--- a/test/lib/spec.template-mixins.js
+++ b/test/lib/spec.template-mixins.js
@@ -255,6 +255,23 @@ describe('Template Mixins', function () {
                 }));
             });
 
+            it('renders group error if context of this is changed', function () {
+                var err = new Error();
+                res.locals.errors = {
+                    'parent': err
+                };
+                res.locals.options.fields = {
+                    'field-name': {
+                        errorGroup: 'parent'
+                    }
+                };
+                middleware(req, res, next);
+                res.locals['input-text']().call(this, 'field-name');
+                render.should.have.been.calledWith(sinon.match({
+                    error: true
+                }));
+            });
+
             it('does not render group error if it is from a group member', function () {
                 var err = new Error();
                 err.errorGroup = 'parent';


### PR DESCRIPTION
The context of `this` is wrong when looping through template mixins. By putting this and res.locals into the same object this corrects this.